### PR TITLE
feat: ブログ記事に読了時間を表示

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
+import { remarkReadingTime } from './remark-reading-time.mjs';
 
 // https://astro.build/config
 export default defineConfig({
@@ -13,6 +14,7 @@ export default defineConfig({
   base: '/astro-keel',
   integrations: [mdx(), sitemap()],
   markdown: {
+    remarkPlugins: [remarkReadingTime],
     // Dual Shiki themes; `defaultColor: false` emits CSS variables
     // (--shiki-light / --shiki-dark) so global.css can switch with the theme.
     shikiConfig: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,9 @@
         "@fontsource-variable/fraunces": "^5.2.9",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource/public-sans": "^5.2.7",
-        "astro": "^7.0.3"
+        "astro": "^7.0.3",
+        "mdast-util-to-string": "^4.0.0",
+        "reading-time": "^1.5.0"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
@@ -5640,6 +5642,12 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/reading-time": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
+      "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
+      "license": "MIT"
     },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "@fontsource-variable/fraunces": "^5.2.9",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource/public-sans": "^5.2.7",
-    "astro": "^7.0.3"
+    "astro": "^7.0.3",
+    "mdast-util-to-string": "^4.0.0",
+    "reading-time": "^1.5.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/remark-reading-time.mjs
+++ b/remark-reading-time.mjs
@@ -1,0 +1,12 @@
+import { toString } from 'mdast-util-to-string';
+import getReadingTime from 'reading-time';
+
+// Injects `minutesRead` (e.g. "3 min read") into every Markdown/MDX entry's
+// frontmatter, exposed at render time via `remarkPluginFrontmatter`.
+export function remarkReadingTime() {
+  return (tree, { data }) => {
+    const textOnPage = toString(tree);
+    const readingTime = getReadingTime(textOnPage);
+    data.astro.frontmatter.minutesRead = readingTime.text;
+  };
+}

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -9,7 +9,7 @@ export async function getStaticPaths() {
 }
 
 const { entry } = Astro.props;
-const { Content, headings } = await render(entry);
+const { Content, headings, remarkPluginFrontmatter } = await render(entry);
 
 const formatDate = (date: Date) =>
   new Intl.DateTimeFormat('en', {
@@ -32,6 +32,7 @@ const formatDate = (date: Date) =>
       <p class="lead">{entry.data.description}</p>
       <div class="entry-meta">
         <time datetime={entry.data.publishDate.toISOString()}>{formatDate(entry.data.publishDate)}</time>
+        <span>{remarkPluginFrontmatter.minutesRead}</span>
         <span>{entry.data.tags.join(' / ')}</span>
       </div>
       {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,10 +1,19 @@
 ---
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { withBase } from '../../lib/url';
 
 const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
   (a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf(),
+);
+
+const readingTimes = new Map(
+  await Promise.all(
+    posts.map(async (post) => {
+      const { remarkPluginFrontmatter } = await render(post);
+      return [post.id, remarkPluginFrontmatter.minutesRead as string] as const;
+    }),
+  ),
 );
 
 const allTags = [...new Set(posts.flatMap((post) => post.data.tags))].sort((a, b) =>
@@ -43,6 +52,7 @@ const formatDate = (date: Date) =>
           <article class="entry-card">
             <div class="entry-meta">
               <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate)}</time>
+              <span>{readingTimes.get(post.id)}</span>
               <span>{post.data.tags.join(' / ')}</span>
             </div>
             <h2><a href={withBase(`/blog/${post.id}/`)}>{post.data.title}</a></h2>

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../../layouts/BaseLayout.astro';
 import { withBase } from '../../../lib/url';
 
@@ -16,6 +16,15 @@ const taggedPosts = posts
   .filter((post) => post.data.tags.includes(tag))
   .sort((a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf());
 const otherTags = tags.filter((item) => item !== tag).sort((a, b) => a.localeCompare(b));
+
+const readingTimes = new Map(
+  await Promise.all(
+    taggedPosts.map(async (post) => {
+      const { remarkPluginFrontmatter } = await render(post);
+      return [post.id, remarkPluginFrontmatter.minutesRead as string] as const;
+    }),
+  ),
+);
 
 const formatDate = (date: Date) =>
   new Intl.DateTimeFormat('en', {
@@ -47,6 +56,7 @@ const formatDate = (date: Date) =>
           <article class="entry-card">
             <div class="entry-meta">
               <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate)}</time>
+              <span>{readingTimes.get(post.id)}</span>
               <span>{post.data.tags.join(' / ')}</span>
             </div>
             <h2><a href={withBase(`/blog/${post.id}/`)}>{post.data.title}</a></h2>


### PR DESCRIPTION
## 概要
Closes #3

issue の提案どおり、公式レシピ（remark + mdast-util-to-string + reading-time）に沿って読了時間を実装しました。

- `remark-reading-time.mjs`: 本文テキストから読了時間を算出し、frontmatter に `minutesRead`（例: `3 min read`）を注入する remark プラグイン
- `astro.config.mjs`: 上記プラグインを `markdown.remarkPlugins` に登録（MDX にも適用される）
- 表示箇所: 記事ヘッダー（`/blog/[slug]`）、ブログ一覧（`/blog`）、タグ別一覧（`/blog/tags/[tag]`）の各 `entry-meta`

## 確認事項
- [x] `npm run dev` でブログ一覧・記事ページ・タグページに読了時間が表示されること
- [x] `npm run build` が通ること（ローカルではビルド未実行）