### PR TITLE
feat: Astro View Transitions (ClientRouter) を導入

### DIFF
--- a/src/components/CodeCopy.astro
+++ b/src/components/CodeCopy.astro
@@ -6,34 +6,38 @@
 <script>
   const IDLE_LABEL = 'Copy';
 
-  for (const pre of document.querySelectorAll('pre')) {
-    const code = pre.querySelector('code');
-    if (!(code instanceof HTMLElement)) continue;
+  // `astro:page-load` fires on the initial load and after every soft
+  // navigation; the swap brings in fresh, button-less `pre` elements.
+  document.addEventListener('astro:page-load', () => {
+    for (const pre of document.querySelectorAll('pre')) {
+      const code = pre.querySelector('code');
+      if (!(code instanceof HTMLElement)) continue;
 
-    const wrapper = document.createElement('div');
-    wrapper.className = 'code-block';
-    pre.replaceWith(wrapper);
-    wrapper.appendChild(pre);
+      const wrapper = document.createElement('div');
+      wrapper.className = 'code-block';
+      pre.replaceWith(wrapper);
+      wrapper.appendChild(pre);
 
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'code-copy';
-    button.textContent = IDLE_LABEL;
-    button.setAttribute('aria-label', 'Copy code to clipboard');
-    button.setAttribute('data-pagefind-ignore', '');
-    button.addEventListener('click', async () => {
-      try {
-        await navigator.clipboard.writeText(code.innerText.replace(/\n$/, ''));
-      } catch {
-        return;
-      }
-      button.textContent = 'Copied';
-      button.classList.add('is-copied');
-      window.setTimeout(() => {
-        button.textContent = IDLE_LABEL;
-        button.classList.remove('is-copied');
-      }, 1600);
-    });
-    wrapper.appendChild(button);
-  }
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'code-copy';
+      button.textContent = IDLE_LABEL;
+      button.setAttribute('aria-label', 'Copy code to clipboard');
+      button.setAttribute('data-pagefind-ignore', '');
+      button.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(code.innerText.replace(/\n$/, ''));
+        } catch {
+          return;
+        }
+        button.textContent = 'Copied';
+        button.classList.add('is-copied');
+        window.setTimeout(() => {
+          button.textContent = IDLE_LABEL;
+          button.classList.remove('is-copied');
+        }, 1600);
+      });
+      wrapper.appendChild(button);
+    }
+  });
 </script>

--- a/src/components/CodeCopy.astro
+++ b/src/components/CodeCopy.astro
@@ -6,12 +6,13 @@
 <script>
   const IDLE_LABEL = 'Copy';
 
-  // `astro:page-load` fires on the initial load and after every soft
-  // navigation; the swap brings in fresh, button-less `pre` elements.
-  document.addEventListener('astro:page-load', () => {
+  // Runs right away (not on `astro:page-load`, which waits for window `load`)
+  // and again after each view-transition swap brings in fresh `pre` elements.
+  const enhance = () => {
     for (const pre of document.querySelectorAll('pre')) {
       const code = pre.querySelector('code');
       if (!(code instanceof HTMLElement)) continue;
+      if (pre.parentElement?.classList.contains('code-block')) continue;
 
       const wrapper = document.createElement('div');
       wrapper.className = 'code-block';
@@ -39,5 +40,8 @@
       });
       wrapper.appendChild(button);
     }
-  });
+  };
+
+  enhance();
+  document.addEventListener('astro:after-swap', enhance);
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,6 +6,7 @@ import '@fontsource/public-sans/600.css';
 import '@fontsource/public-sans/700.css';
 import '@fontsource-variable/jetbrains-mono/wght.css';
 import '../styles/global.css';
+import { ClientRouter } from 'astro:transitions';
 import { withBase } from '../lib/url';
 import { SITE, NAV_ITEMS } from '../consts';
 import CodeCopy from '../components/CodeCopy.astro';
@@ -69,10 +70,17 @@ const isActive = (href: string) => {
     <meta name="twitter:description" content={description} />
     {imageURL && <meta name="twitter:image" content={imageURL} />}
     <slot name="head" />
+    <ClientRouter />
     <script is:inline>
-      const storedTheme = localStorage.getItem('theme');
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      document.documentElement.dataset.theme = storedTheme || (prefersDark ? 'dark' : 'light');
+      // Runs before paint on the initial load, and again on `astro:after-swap`
+      // because the router resets `<html>` attributes during soft navigation.
+      const applyTheme = () => {
+        const storedTheme = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.dataset.theme = storedTheme || (prefersDark ? 'dark' : 'light');
+      };
+      applyTheme();
+      document.addEventListener('astro:after-swap', applyTheme);
     </script>
   </head>
   <body>
@@ -111,8 +119,12 @@ const isActive = (href: string) => {
     <CodeCopy />
 
     <script>
-      const toggle = document.querySelector('[data-theme-toggle]');
-      toggle?.addEventListener('click', () => {
+      // Delegated to `document` so the handler survives view-transition swaps
+      // that replace the toggle button element.
+      document.addEventListener('click', (event) => {
+        if (!(event.target instanceof Element) || !event.target.closest('[data-theme-toggle]')) {
+          return;
+        }
         const current = document.documentElement.dataset.theme;
         const next = current === 'dark' ? 'light' : 'dark';
         document.documentElement.dataset.theme = next;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -74,13 +74,16 @@ const isActive = (href: string) => {
     <script is:inline>
       // Runs before paint on the initial load, and again on `astro:after-swap`
       // because the router resets `<html>` attributes during soft navigation.
-      const applyTheme = () => {
-        const storedTheme = localStorage.getItem('theme');
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        document.documentElement.dataset.theme = storedTheme || (prefersDark ? 'dark' : 'light');
-      };
-      applyTheme();
-      document.addEventListener('astro:after-swap', applyTheme);
+      // IIFE so top-level consts can't clash if the script ever re-runs.
+      (() => {
+        const applyTheme = () => {
+          const storedTheme = localStorage.getItem('theme');
+          const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          document.documentElement.dataset.theme = storedTheme || (prefersDark ? 'dark' : 'light');
+        };
+        applyTheme();
+        document.addEventListener('astro:after-swap', applyTheme);
+      })();
     </script>
   </head>
   <body>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -22,10 +22,11 @@ const bundlePath = withBase('/pagefind/');
         preview the site to try it — it is not available on the dev server.
       </p>
     </div>
-    <script is:inline define:vars={{ bundlePath }}>
-      const script = document.createElement('script');
-      script.src = `${bundlePath}pagefind-ui.js`;
-      script.onload = () => {
+    <script is:inline data-astro-rerun define:vars={{ bundlePath }}>
+      // `data-astro-rerun` re-runs this after each soft navigation, because the
+      // swap replaces `#search` with an empty container. The UI script itself is
+      // only loaded once and reused on later visits.
+      const initSearch = () => {
         document.querySelector('#search .search-fallback')?.remove();
         new PagefindUI({
           element: '#search',
@@ -35,7 +36,14 @@ const bundlePath = withBase('/pagefind/');
           autofocus: true,
         });
       };
-      document.head.append(script);
+      if (window.PagefindUI) {
+        initSearch();
+      } else {
+        const script = document.createElement('script');
+        script.src = `${bundlePath}pagefind-ui.js`;
+        script.onload = initSearch;
+        document.head.append(script);
+      }
     </script>
   </section>
 </BaseLayout>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -6,6 +6,7 @@ const bundlePath = withBase('/pagefind/');
 ---
 
 <BaseLayout title="Search" description="Search posts and works — Astro Keel.">
+  <link slot="head" rel="stylesheet" href={`${bundlePath}pagefind-ui.css`} />
   <section class="page-head section">
     <p class="eyebrow">Search</p>
     <h1>Find posts and works.</h1>
@@ -15,35 +16,41 @@ const bundlePath = withBase('/pagefind/');
   </section>
 
   <section class="section search-section" aria-label="Site search">
-    <link rel="stylesheet" href={`${bundlePath}pagefind-ui.css`} />
-    <div id="search">
+    <div id="search" data-bundle-path={bundlePath}>
       <p class="search-fallback">
         The search index is generated at build time. Run <code>npm run build</code> and
         preview the site to try it — it is not available on the dev server.
       </p>
     </div>
-    <script is:inline data-astro-rerun define:vars={{ bundlePath }}>
+    <script is:inline data-astro-rerun>
       // `data-astro-rerun` re-runs this after each soft navigation, because the
-      // swap replaces `#search` with an empty container. The UI script itself is
-      // only loaded once and reused on later visits.
-      const initSearch = () => {
-        document.querySelector('#search .search-fallback')?.remove();
-        new PagefindUI({
-          element: '#search',
-          bundlePath,
-          showImages: false,
-          showSubResults: true,
-          autofocus: true,
-        });
-      };
-      if (window.PagefindUI) {
-        initSearch();
-      } else {
-        const script = document.createElement('script');
-        script.src = `${bundlePath}pagefind-ui.js`;
-        script.onload = initSearch;
-        document.head.append(script);
-      }
+      // swap replaces `#search` with an empty container. `bundlePath` comes from
+      // a data attribute — `define:vars` would strip `data-astro-rerun` from the
+      // rendered tag. The IIFE keeps re-runs from redeclaring top-level consts;
+      // the UI script itself is only loaded once and reused on later visits.
+      (() => {
+        const container = document.getElementById('search');
+        if (!container) return;
+        const bundlePath = container.dataset.bundlePath;
+        const initSearch = () => {
+          container.querySelector('.search-fallback')?.remove();
+          new PagefindUI({
+            element: '#search',
+            bundlePath,
+            showImages: false,
+            showSubResults: true,
+            autofocus: true,
+          });
+        };
+        if (window.PagefindUI) {
+          initSearch();
+        } else {
+          const script = document.createElement('script');
+          script.src = `${bundlePath}pagefind-ui.js`;
+          script.onload = initSearch;
+          document.head.append(script);
+        }
+      })();
     </script>
   </section>
 </BaseLayout>


### PR DESCRIPTION
Closes #16

## 変更内容
- `BaseLayout.astro` の `<head>` に `<ClientRouter />` を追加し、ページ遷移をビュートランジション化
- テーマ初期化スクリプトを `astro:after-swap` でも再適用するように変更（ソフトナビゲーション時にルーターが `<html>` 属性をリセットするため。swap は描画前に発火するのでフラッシュなし）
- テーマトグルのクリックハンドラを `document` への委譲に変更（swap でボタン要素が差し替わってもリスナーが生き続ける）
- コピーボタン注入（`CodeCopy.astro`）を `astro:page-load`（初回ロード＋各ソフトナビゲーション後に発火）でラップ
- Pagefind 初期化（`search.astro`）に `data-astro-rerun` を付与し、`pagefind-ui.js` 本体は `window.PagefindUI` の有無で一度だけロードする冪等な構成に変更

## 補足
- `prefers-reduced-motion` は Astro が標準で尊重（アニメーションなしの即時スワップにフォールバック）するため追加対応なし
- ヘッダーの `transition:persist` は見送り。永続化するとページごとにサーバーレンダリングされる `aria-current`（アクティブなナビ表示）が古いまま残るため

## 確認
- `npm run check`: 0 errors / 0 warnings
- `npm run build` + Pagefind インデックス生成: 成功。`dist` 出力に ClientRouter スクリプトと `data-astro-rerun` が含まれることを確認