### PR TITLE
docs: community health files, changelog, and verified Lighthouse scores

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Something in the theme is broken or behaves unexpectedly.
+title: '[Bug]: '
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. A minimal reproduction is
+        by far the most useful thing you can give us.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what did you get instead?
+      placeholder: The tag archive shows page 2 links even when there is only one page.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Numbered steps, or a link to a repository / StackBlitz that reproduces it.
+      placeholder: |
+        1. `npm create astro@latest -- --template kpab/astro-keel`
+        2. Add a post with `draft: true`
+        3. Run `npm run build`
+        4. See the error
+    validations:
+      required: true
+
+  - type: input
+    id: astro-version
+    attributes:
+      label: Astro version
+      description: Output of `npx astro --version`.
+      placeholder: '7.0.3'
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Output of `node --version`. The theme requires Node 22.12+.
+      placeholder: 'v22.12.0'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Only for rendering, theme-toggle, or search issues.
+      placeholder: 'Chrome 141, Safari 26'
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Build output or console errors
+      description: |
+        Paste the relevant part of `npm run build` / `npm run check` output, or
+        the browser console. This is automatically formatted as code.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues and did not find a duplicate.
+          required: true
+        - label: I am on Node.js 22.12 or newer.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Live demo
+    url: https://kpab.github.io/astro-keel/
+    about: See the theme running before filing an issue — the behavior may be intentional.
+  - name: Setup & configuration docs
+    url: https://github.com/kpab/astro-keel#configuration
+    about: Site config, base path, accent color, fonts, and deployment are covered in the README.
+  - name: Contributing guide
+    url: https://github.com/kpab/astro-keel/blob/main/CONTRIBUTING.md
+    about: Dev setup, project structure, and pull request conventions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Suggest a capability or improvement for the theme.
+title: '[Feature]: '
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Astro Keel aims to stay **minimal by default**. Larger features are
+        welcome, but they generally need to be opt-in via `src/consts.ts` so the
+        default build stays lean.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case rather than the implementation.
+      placeholder: I publish in two languages and have to fork every template to translate the nav labels.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should the theme do? Which files would it touch?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: default-behavior
+    attributes:
+      label: How should it ship?
+      options:
+        - Opt-in via a flag in src/consts.ts
+        - On by default (no config)
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing workarounds, or other themes/plugins that solve this.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues and did not find a duplicate.
+          required: true
+        - label: I am willing to open a pull request for this.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+Thanks for contributing to Astro Keel! Please keep the description short —
+the "what" and the "why" are enough.
+-->
+
+## What
+
+<!-- One or two sentences on what this changes. -->
+
+## Why
+
+<!-- The problem it solves. Link the issue: "Closes #123". -->
+
+Closes #
+
+## Screenshots
+
+<!--
+Required for any visual change. Light *and* dark mode, please — the theme
+ships both. Delete this section for non-visual changes.
+-->
+
+## Checklist
+
+- [ ] `npm run check` passes (0 errors)
+- [ ] `npm run build` succeeds
+- [ ] Verified in both light and dark mode (visual changes only)
+- [ ] New config options are documented in `src/consts.ts` comments and the README
+- [ ] New features that add client-side weight are opt-in (off by default)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Because Astro Keel is a **template**, "upgrading" usually means porting the
+changes below into your own copy rather than bumping a dependency. Entries are
+written with that in mind — each one names the files it touches.
+
+## [Unreleased]
+
+### Added
+
+- **Static search** at `/search`, powered by [Pagefind](https://pagefind.app/)
+  and indexed at build time via a `postbuild` script — zero backend.
+- **Pagination** on the blog index and tag archives, 10 posts per page
+  (`src/components/Pagination.astro`).
+- **Auto-generated Open Graph images** for every post and work, rendered at
+  build time with `satori` + `sharp` (`src/pages/og/[collection]/[slug].png.ts`).
+- **Reading time** on blog posts, via a `remark` plugin (`remark-reading-time.mjs`).
+- **View Transitions** — `<ClientRouter />` for soft navigation between pages,
+  with the theme toggle, Pagefind, and code-copy buttons re-initialized on
+  `astro:page-load` / `astro:after-swap`.
+- **JSON-LD structured data** — `WebSite` on the home page, `BlogPosting` +
+  `BreadcrumbList` on posts (`src/components/StructuredData.astro`). The author
+  is configurable through `SITE.author`.
+- **Copy buttons on code blocks** (`src/components/CodeCopy.astro`).
+- **Previous / next post navigation** at the end of each blog post.
+- **Related posts** section, matched on shared tags.
+- **Configurable social links** in the footer — declare them in `SOCIAL_LINKS`
+  in `src/consts.ts` and they render as inline SVG icons
+  (`src/components/SocialLinks.astro`).
+- **Custom 404 page** (`src/pages/404.astro`).
+- Sticky top bar on scroll.
+- Default Open Graph image (`public/og.jpg`), work thumbnails, and a hero image
+  for the sample posts.
+
+### Changed
+
+- Site identity (title, description, RSS description, share image, author,
+  footer text, nav items) is centralized in `src/consts.ts`.
+- README rewritten: badge header, light/dark preview screenshots, and expanded
+  configuration and deployment sections.
+- Content images recompressed to JPEG for lighter social sharing.
+- Section spacing tightened so the hero and its call to action fit a laptop
+  viewport.
+
+### Fixed
+
+- Theme toggle now sits at the right edge of the first row on mobile.
+- Section padding no longer showed the divider background behind the works list
+  and the about ledger.
+- Hero heading size capped so the call to action stays above the fold.
+
+## [0.1.0] - 2026-06-27
+
+Initial release.
+
+### Added
+
+- Astro 7 project with MDX, `@astrojs/sitemap`, and `@astrojs/rss`.
+- `works` and `blog` content collections on the Content Layer API, with listing
+  and detail pages for each.
+- Per-tag blog archives at `/blog/tags/[tag]`.
+- RSS feed at `/rss.xml`.
+- Structural-minimalist design system: OKLCH theme tokens, a single
+  `--color-accent` variable, and self-hosted Fraunces / Public Sans /
+  JetBrains Mono via `@fontsource`.
+- Light and dark mode honoring `prefers-color-scheme`, with a header toggle
+  persisted to `localStorage` and no flash on load.
+- Shiki dual themes emitted as CSS variables so highlighting follows the active
+  color scheme.
+- Canonical URLs, Open Graph, and Twitter card meta in the base layout.
+- Base-path-aware internal links through `withBase()` (`src/lib/url.ts`).
+- GitHub Pages deployment workflow (`.github/workflows/deploy.yml`), building on
+  Node 22.
+- `npm run check` (`astro check`) wired up, MIT license, and the theme README.
+
+[Unreleased]: https://github.com/kpab/astro-keel/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/kpab/astro-keel/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ written with that in mind — each one names the files it touches.
   (`src/components/SocialLinks.astro`).
 - **Custom 404 page** (`src/pages/404.astro`).
 - Sticky top bar on scroll.
+- Community health files — issue forms, a pull request template,
+  `CONTRIBUTING.md`, and this changelog.
 - Default Open Graph image (`public/og.jpg`), work thumbnails, and a hero image
   for the sample posts.
 
@@ -53,6 +55,10 @@ written with that in mind — each one names the files it touches.
 - Section padding no longer showed the divider background behind the works list
   and the about ledger.
 - Hero heading size capped so the call to action stays above the fold.
+- Filled `.button` text now uses a per-scheme `--color-on-accent` token. The
+  dark-scheme accent is light, so near-white label text only reached a 2.53:1
+  contrast ratio; the dark demo page now passes WCAG AA and Lighthouse
+  accessibility scores 100.
 
 ## [0.1.0] - 2026-06-27
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,9 @@ npm run check    # astro check — must report 0 errors
 npm run build    # must succeed; also runs `pagefind` via postbuild
 ```
 
-`npm run check` currently emits two Zod deprecation hints from Astro's content
-schema API. Those are pre-existing — new *errors* are not acceptable, new hints
-should be avoided.
+`npm run check` currently emits four hints: two Zod deprecations from Astro's
+content schema API, and two unused-`Props` hints in the paginated routes. Those
+are pre-existing — new *errors* are not acceptable, new hints should be avoided.
 
 ## Project structure
 
@@ -95,11 +95,21 @@ Maintainers only.
    git push origin main --tags
    ```
 
-4. Publish the GitHub Release with the changelog section as the body:
+4. Publish the GitHub Release, using that changelog section as the body — paste
+   it in and close with `Ctrl-D`:
 
    ```sh
-   gh release create vx.y.z --title "vx.y.z" --notes-file <(…)
+   gh release create vx.y.z --title "vx.y.z" --notes-file -
    ```
+
+The Lighthouse table in the README is a hand-recorded snapshot, not a live
+badge — re-run it before cutting a release so a regression can't sit behind a
+stale 100:
+
+```sh
+npm run build && npm run preview
+npx lighthouse http://localhost:4321/astro-keel/ --preset=desktop --view
+```
 
 Versioning is [Semantic Versioning](https://semver.org/): a breaking change to
 `src/consts.ts`, the content schemas, or the required Node version bumps the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing to Astro Keel
+
+Thanks for your interest in improving the theme. Bug reports, docs fixes, and
+focused pull requests are all welcome.
+
+## Design principles
+
+Astro Keel is a **minimal** theme, and staying minimal is a feature. Two rules
+follow from that:
+
+1. **Ship zero client-side JavaScript by default.** Anything that adds runtime
+   weight (comment widgets, analytics, animation libraries) must be opt-in via a
+   flag in `src/consts.ts` and emit nothing when disabled.
+2. **Configuration lives in one place.** New knobs go in `src/consts.ts` with a
+   doc comment, not scattered across templates. A user should be able to rebrand
+   the theme without editing `.astro` files.
+
+## Development setup
+
+Requires **Node.js 22.12 or newer** (Astro 7).
+
+```sh
+git clone https://github.com/kpab/astro-keel.git
+cd astro-keel
+npm install
+npm run dev      # dev server at http://localhost:4321/astro-keel/
+```
+
+Note the `/astro-keel/` path — `astro.config.mjs` sets `base` for the GitHub
+Pages demo. Leave it as-is in PRs; downstream users drop it for a root domain.
+
+Before pushing:
+
+```sh
+npm run check    # astro check — must report 0 errors
+npm run build    # must succeed; also runs `pagefind` via postbuild
+```
+
+`npm run check` currently emits two Zod deprecation hints from Astro's content
+schema API. Those are pre-existing — new *errors* are not acceptable, new hints
+should be avoided.
+
+## Project structure
+
+```
+src/
+  consts.ts          # site identity, nav, social links, feature flags
+  content.config.ts  # collection schemas (Content Layer API)
+  content/           # works/ and blog/ Markdown & MDX entries
+  layouts/           # BaseLayout — head, nav, theme toggle, footer
+  components/        # Pagination, SocialLinks, CodeCopy, StructuredData…
+  pages/             # routes: /, /about, /works, /blog, tags, search, rss.xml
+  lib/url.ts         # withBase() — always use it for internal links/assets
+  styles/global.css  # design tokens (OKLCH), typography, layout primitives
+astro.config.mjs     # site URL, base path, integrations, Shiki config
+```
+
+Two things that trip people up:
+
+- **Always route internal links through `withBase()`** (`src/lib/url.ts`).
+  Hard-coded `/blog/` links break every deployment that uses a `base` path.
+- **The theme uses View Transitions** (`<ClientRouter />`). Scripts that touch
+  the DOM must re-run after soft navigation — listen for `astro:page-load` or
+  `astro:after-swap` rather than relying on a single initial execution.
+
+## Pull requests
+
+- Branch from `main`. Use a descriptive branch name (`feat/…`, `fix/…`, `docs/…`).
+- **Keep commits small** — one logical change per commit.
+- Commit subjects follow [Conventional Commits](https://www.conventionalcommits.org/)
+  (`feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `perf:`, `chore:`).
+- Include **light and dark mode screenshots** for any visual change.
+- One concern per PR. Unrelated drive-by refactors make review slow.
+- Add an entry under `## [Unreleased]` in [CHANGELOG.md](./CHANGELOG.md) for
+  user-visible changes.
+
+## Reporting bugs
+
+Open an issue with the **Bug report** form. A reproduction — even just the exact
+frontmatter and the build output — resolves reports far faster than a
+description alone.
+
+## Release procedure
+
+Maintainers only.
+
+1. Move the `## [Unreleased]` entries in `CHANGELOG.md` into a new
+   `## [x.y.z] - YYYY-MM-DD` section and update the link definitions at the
+   bottom of the file.
+2. Bump `version` in `package.json` to match.
+3. Commit as `chore: release vx.y.z`, then tag and push:
+
+   ```sh
+   git tag vx.y.z
+   git push origin main --tags
+   ```
+
+4. Publish the GitHub Release with the changelog section as the body:
+
+   ```sh
+   gh release create vx.y.z --title "vx.y.z" --notes-file <(…)
+   ```
+
+Versioning is [Semantic Versioning](https://semver.org/): a breaking change to
+`src/consts.ts`, the content schemas, or the required Node version bumps the
+major (or the minor, while the theme is pre-1.0).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A calm neutral base, a single configurable accent color, generous whitespace, an
 
 <br />
 
+[![Lighthouse: 100/100/100/100](https://img.shields.io/badge/Lighthouse-100%20%C2%B7%20100%20%C2%B7%20100%20%C2%B7%20100-0cce6b?style=flat-square&logo=lighthouse&logoColor=white)](#lighthouse)
+<br />
+
 [![Deploy](https://img.shields.io/github/actions/workflow/status/kpab/astro-keel/deploy.yml?branch=main&style=flat-square&label=deploy)](https://github.com/kpab/astro-keel/actions/workflows/deploy.yml)
 [![License](https://img.shields.io/github/license/kpab/astro-keel?style=flat-square&color=1a1a1a)](./LICENSE)
 [![Stars](https://img.shields.io/github/stars/kpab/astro-keel?style=flat-square&color=1a1a1a)](https://github.com/kpab/astro-keel/stargazers)
@@ -62,6 +65,26 @@ A calm neutral base, a single configurable accent color, generous whitespace, an
 - **JSON-LD structured data** — `WebSite` on the home page, `BlogPosting` + `BreadcrumbList` on posts (author configurable via `SITE.author` in `src/consts.ts`).
 - **Responsive & accessible** — fluid type, hairline structure, visible focus rings.
 - **One-click deploy** — bundled GitHub Pages workflow; or ship the static `dist/` to Cloudflare Pages, Vercel, Netlify, or any static host.
+
+## Lighthouse
+
+Every page of the demo scores **100 across all four categories** — with search,
+pagination, and generated OG images all switched on.
+
+| Page | Performance | Accessibility | Best Practices | SEO |
+| --- | :---: | :---: | :---: | :---: |
+| Home `/` | 100 | 100 | 100 | 100 |
+| Blog index `/blog/` | 100 | 100 | 100 | 100 |
+| Blog post `/blog/baseline-rhythm/` | 100 | 100 | 100 | 100 |
+| Works `/works/` | 100 | 100 | 100 | 100 |
+| Search `/search/` | 100 | 100 | 100 | 100 |
+
+<sub>Lighthouse 13.4.1, desktop preset, production build. Reproduce it yourself:</sub>
+
+```sh
+npm run build && npm run preview
+npx lighthouse http://localhost:4321/astro-keel/ --preset=desktop --view
+```
 
 ## Tech stack
 
@@ -217,6 +240,20 @@ A workflow at `.github/workflows/deploy.yml` builds the site and publishes it on
 ### Other static hosts
 
 `npm run build` emits a static `dist/` that deploys as-is to Cloudflare Pages, Vercel, Netlify, or any static host. Drop `base` from `astro.config.mjs` when serving from a domain root.
+
+## Changelog
+
+Notable changes are recorded in [CHANGELOG.md](./CHANGELOG.md), and tagged
+versions are published as [GitHub Releases](https://github.com/kpab/astro-keel/releases).
+Because this is a template rather than a dependency, upgrading means porting the
+changes you want into your own copy — each entry names the files it touches.
+
+## Contributing
+
+Bug reports, docs fixes, and focused pull requests are welcome. See
+[CONTRIBUTING.md](./CONTRIBUTING.md) for dev setup, project structure, and the
+two design rules the theme holds to (zero client JS by default; all
+configuration in `src/consts.ts`).
 
 ## More themes by kpab
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,8 @@
   --color-accent: oklch(0.54 0.14 35);
   --color-accent-hover: color-mix(in oklch, var(--color-accent), black 12%);
   --color-accent-soft: color-mix(in oklch, var(--color-accent), transparent 84%);
+  /* Text/icon color on top of a filled accent surface. */
+  --color-on-accent: oklch(0.99 0.003 100);
   --color-bg: oklch(0.99 0.003 100);
   --color-surface: oklch(0.965 0.004 100);
   --color-text: oklch(0.25 0.01 250);
@@ -28,6 +30,8 @@
     --color-accent: oklch(0.72 0.13 42);
     --color-accent-hover: color-mix(in oklch, var(--color-accent), white 10%);
     --color-accent-soft: color-mix(in oklch, var(--color-accent), transparent 78%);
+  /* The dark-scheme accent is light, so filled surfaces need dark text. */
+  --color-on-accent: oklch(0.18 0.009 250);
     --color-bg: oklch(0.18 0.009 250);
     --color-surface: oklch(0.22 0.01 250);
     --color-text: oklch(0.93 0.006 95);
@@ -43,6 +47,8 @@
   --color-accent: oklch(0.54 0.14 35);
   --color-accent-hover: color-mix(in oklch, var(--color-accent), black 12%);
   --color-accent-soft: color-mix(in oklch, var(--color-accent), transparent 84%);
+  /* Text/icon color on top of a filled accent surface. */
+  --color-on-accent: oklch(0.99 0.003 100);
   --color-bg: oklch(0.99 0.003 100);
   --color-surface: oklch(0.965 0.004 100);
   --color-text: oklch(0.25 0.01 250);
@@ -57,6 +63,8 @@
   --color-accent: oklch(0.72 0.13 42);
   --color-accent-hover: color-mix(in oklch, var(--color-accent), white 10%);
   --color-accent-soft: color-mix(in oklch, var(--color-accent), transparent 78%);
+  /* The dark-scheme accent is light, so filled surfaces need dark text. */
+  --color-on-accent: oklch(0.18 0.009 250);
   --color-bg: oklch(0.18 0.009 250);
   --color-surface: oklch(0.22 0.01 250);
   --color-text: oklch(0.93 0.006 95);
@@ -343,7 +351,7 @@ p {
   padding: 0.72rem 1.05rem;
   border: 1px solid var(--color-accent);
   background: var(--color-accent);
-  color: oklch(0.99 0.003 100);
+  color: var(--color-on-accent);
   font-weight: 700;
   transition:
     background 180ms ease,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,8 +30,8 @@
     --color-accent: oklch(0.72 0.13 42);
     --color-accent-hover: color-mix(in oklch, var(--color-accent), white 10%);
     --color-accent-soft: color-mix(in oklch, var(--color-accent), transparent 78%);
-  /* The dark-scheme accent is light, so filled surfaces need dark text. */
-  --color-on-accent: oklch(0.18 0.009 250);
+    /* The dark-scheme accent is light, so filled surfaces need dark text. */
+    --color-on-accent: oklch(0.18 0.009 250);
     --color-bg: oklch(0.18 0.009 250);
     --color-surface: oklch(0.22 0.01 250);
     --color-text: oklch(0.93 0.006 95);


### PR DESCRIPTION
## What

Community health files, release management, and the Lighthouse claim in the README.

Closes #18
Closes #19
Closes #6

## Why

Three docs-shaped issues that all touch the repo's front door, so they land together.

### #18 — community health files
- `.github/ISSUE_TEMPLATE/bug_report.yml` — Astro/Node version, OS, browser, reproduction, build output, with blank issues disabled.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — asks up front whether the feature should be opt-in, since "minimal by default" is the constraint most proposals run into.
- `.github/ISSUE_TEMPLATE/config.yml` — contact links to the live demo, the README config section, and CONTRIBUTING. (GitHub Discussions is not enabled on this repo, so there is no Discussions link.)
- `.github/PULL_REQUEST_TEMPLATE.md` — what/why, light+dark screenshots, `npm run check` / `npm run build` checklist.
- `CONTRIBUTING.md` — design principles, dev setup (Node 22.12+, the `/astro-keel/` base path), project structure, the two footguns (`withBase()` and re-running scripts after View Transitions), PR conventions, and the release procedure.

### #19 — release management
- `CHANGELOG.md` in Keep a Changelog format. `0.1.0` is backfilled from git history; `Unreleased` covers everything since the tag (search, pagination, OG images, reading time, View Transitions, JSON-LD, copy buttons, prev/next, related posts, social links, 404).
- Linked from the README; the release procedure is documented in CONTRIBUTING.
- The GitHub Release for the existing `v0.1.0` tag is published separately (it needs no code change).

### #6 — Lighthouse scores
Running Lighthouse against the deployed demo turned up a real accessibility defect: the filled `.button` hard-coded near-white label text, but the dark-scheme accent is light (`oklch(0.72 0.13 42)`), giving a **2.53:1** contrast ratio — below WCAG AA. Dark-mode accessibility scored 95, not 100.

Rather than publish a 95, this PR fixes it: a new per-scheme `--color-on-accent` token (near-white in light, near-black in dark) replaces the hard-coded value. Light mode is visually unchanged; dark-mode buttons now have dark label text.

With that fix, every page scores 100/100/100/100:

| Page | Perf | A11y | Best Practices | SEO |
| --- | :---: | :---: | :---: | :---: |
| `/` | 100 | 100 | 100 | 100 |
| `/blog/` | 100 | 100 | 100 | 100 |
| `/blog/baseline-rhythm/` | 100 | 100 | 100 | 100 |
| `/works/` | 100 | 100 | 100 | 100 |
| `/search/` | 100 | 100 | 100 | 100 |

Lighthouse 13.4.1, desktop preset, production build (`npm run build && npm run preview`). The README documents the exact command so the claim is reproducible.

## Screenshots

The only visual change is the dark-mode filled button label (white → near-black on the accent fill). Light mode is untouched.

## Checklist

- [x] `npm run check` passes (0 errors, 4 pre-existing hints)
- [x] `npm run build` succeeds
- [x] Verified in both light and dark mode
- [x] New config options documented — n/a, no new `consts.ts` options
- [x] No new client-side weight
