### PR TITLE
feat: optional Giscus comments on blog posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ written with that in mind — each one names the files it touches.
 - Sticky top bar on scroll.
 - Community health files — issue forms, a pull request template,
   `CONTRIBUTING.md`, and this changelog.
+- **Optional Giscus comments** on blog posts, configured through `GISCUS` in
+  `src/consts.ts` and **off by default** — a disabled build emits no Giscus
+  markup, styles, or script at all. When enabled, the widget loads only once the
+  reader scrolls near it, follows the light/dark toggle live, and falls back to
+  a GitHub Discussions link if the embed never appears
+  (`src/components/Comments.astro`).
 - Default Open Graph image (`public/og.jpg`), work thumbnails, and a hero image
   for the sample posts.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A calm neutral base, a single configurable accent color, generous whitespace, an
 - **Static search** — zero-backend full-text search at `/search` powered by [Pagefind](https://pagefind.app/), indexed at build time.
 - **Auto OG images** — per-post and per-work Open Graph images rendered at build time with `satori` + `sharp`.
 - **Table of contents** — blog posts get an auto-generated sidebar TOC from their headings.
+- **Optional comments** — [Giscus](https://giscus.app) threads on blog posts, opt-in via `src/consts.ts`, lazy-loaded and theme-synced; disabled builds ship zero Giscus bytes.
 - **RSS feed** — generated at `/rss.xml` with `@astrojs/rss`.
 - **Syntax highlighting** — Shiki dual themes (light/dark) wired to the active color scheme.
 - **SEO-ready** — canonical URLs, Open Graph, Twitter cards, and a sitemap out of the box.
@@ -134,6 +135,37 @@ export const SOCIAL_LINKS: readonly SocialLink[] = [
 ```
 
 Built-in icons: `github`, `x`, `linkedin`, `rss`, `email`. Site-root paths (like `/rss.xml`) get the configured `base` applied automatically; `mailto:` and full URLs are used as-is.
+
+### Comments (optional)
+
+Blog posts can carry a [Giscus](https://giscus.app) thread — comments backed by
+GitHub Discussions, so there is still no backend to run. **Off by default:** with
+`enabled: false`, not a single byte of Giscus markup or script reaches the
+browser.
+
+To turn it on:
+
+1. Make the repository public and enable **Discussions** in its settings.
+2. Install the [giscus GitHub App](https://github.com/apps/giscus) on it.
+3. Fill in the generated values from [giscus.app](https://giscus.app) in
+   `src/consts.ts`:
+
+```ts
+export const GISCUS: GiscusConfig = {
+  enabled: true,
+  repo: '<user>/<repo>',
+  repoId: 'R_...',        // from giscus.app
+  category: 'Announcements',
+  categoryId: 'DIC_...',  // from giscus.app
+  mapping: 'pathname',    // survives retitling, unlike 'title'
+  // ...
+};
+```
+
+The widget loads only when the reader scrolls near it (`IntersectionObserver`),
+so it never competes with the article for bandwidth, and its theme follows the
+header's light/dark toggle live — set `lightTheme` / `darkTheme` to any Giscus
+theme name or a URL to your own theme CSS.
 
 ### Site URL
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ Built-in icons: `github`, `x`, `linkedin`, `rss`, `email`. Site-root paths (like
 
 Blog posts can carry a [Giscus](https://giscus.app) thread — comments backed by
 GitHub Discussions, so there is still no backend to run. **Off by default:** with
-`enabled: false`, not a single byte of Giscus markup or script reaches the
-browser.
+`enabled: false`, not a single byte of Giscus markup, CSS, or script reaches the
+browser — the whole component, styles included, sits behind the flag.
 
 To turn it on:
 
@@ -165,7 +165,9 @@ export const GISCUS: GiscusConfig = {
 The widget loads only when the reader scrolls near it (`IntersectionObserver`),
 so it never competes with the article for bandwidth, and its theme follows the
 header's light/dark toggle live — set `lightTheme` / `darkTheme` to any Giscus
-theme name or a URL to your own theme CSS.
+theme name or a URL to your own theme CSS. If the embed never appears — a
+content blocker, an offline reader, or an unfinished repository setup — a link
+to the discussion thread replaces it rather than leaving an empty box.
 
 ### Site URL
 

--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -1,0 +1,109 @@
+---
+// Giscus comments — opt-in. Everything below (markup *and* script) sits behind
+// the `enabled` check, so a default build ships zero Giscus bytes.
+import { GISCUS } from '../consts';
+
+// Guard on the IDs too: a half-filled config would render a widget that can
+// never resolve a discussion.
+const enabled = Boolean(GISCUS.enabled && GISCUS.repo && GISCUS.repoId && GISCUS.categoryId);
+---
+
+{
+  enabled && (
+    <section class="section post-nav-section comments-section" aria-labelledby="comments-heading" data-pagefind-ignore>
+      <p class="eyebrow" id="comments-heading">
+        Comments
+      </p>
+      <div
+        class="comments-mount"
+        data-giscus
+        data-repo={GISCUS.repo}
+        data-repo-id={GISCUS.repoId}
+        data-category={GISCUS.category}
+        data-category-id={GISCUS.categoryId}
+        data-mapping={GISCUS.mapping}
+        data-strict={GISCUS.strict ? '1' : '0'}
+        data-reactions-enabled={GISCUS.reactionsEnabled ? '1' : '0'}
+        data-input-position={GISCUS.inputPosition}
+        data-lang={GISCUS.lang}
+        data-light-theme={GISCUS.lightTheme}
+        data-dark-theme={GISCUS.darkTheme}
+      >
+        <noscript>
+          <p class="comments-fallback">Comments require JavaScript. They are hosted on GitHub Discussions.</p>
+        </noscript>
+      </div>
+
+      <script is:inline data-astro-rerun>
+        // `is:inline` keeps this out of the shared bundle so a disabled config
+        // emits nothing at all. `data-astro-rerun` re-runs it after each soft
+        // navigation, since the swap replaces the mount with an empty one.
+        // Config arrives through data attributes — `define:vars` would strip
+        // `data-astro-rerun` from the rendered tag. IIFE so re-runs can't
+        // redeclare top-level consts.
+        (() => {
+          const mount = document.querySelector('[data-giscus]');
+          if (!mount || mount.dataset.loaded) return;
+
+          const config = mount.dataset;
+          const themeFor = (scheme) => (scheme === 'dark' ? config.darkTheme : config.lightTheme);
+
+          const load = () => {
+            if (mount.dataset.loaded) return;
+            mount.dataset.loaded = '1';
+            const script = document.createElement('script');
+            script.src = 'https://giscus.app/client.js';
+            script.async = true;
+            script.crossOrigin = 'anonymous';
+            script.setAttribute('data-repo', config.repo);
+            script.setAttribute('data-repo-id', config.repoId);
+            script.setAttribute('data-category', config.category);
+            script.setAttribute('data-category-id', config.categoryId);
+            script.setAttribute('data-mapping', config.mapping);
+            script.setAttribute('data-strict', config.strict);
+            script.setAttribute('data-reactions-enabled', config.reactionsEnabled);
+            script.setAttribute('data-emit-metadata', '0');
+            script.setAttribute('data-input-position', config.inputPosition);
+            script.setAttribute('data-lang', config.lang);
+            script.setAttribute('data-loading', 'lazy');
+            script.setAttribute('data-theme', themeFor(document.documentElement.dataset.theme));
+            mount.appendChild(script);
+          };
+
+          // Defer the third-party request until the reader is near the thread,
+          // so comments never compete with the article for bandwidth.
+          if ('IntersectionObserver' in window) {
+            const observer = new IntersectionObserver(
+              (entries) => {
+                if (!entries.some((entry) => entry.isIntersecting)) return;
+                observer.disconnect();
+                load();
+              },
+              { rootMargin: '400px 0px' },
+            );
+            observer.observe(mount);
+          } else {
+            load();
+          }
+
+          // Keep the widget in sync with the header toggle. The theme lives on
+          // `<html data-theme>`, so watch that attribute rather than the button.
+          const syncTheme = () => {
+            const frame = mount.querySelector('iframe.giscus-frame');
+            if (!frame) return;
+            frame.contentWindow?.postMessage(
+              { giscus: { setConfig: { theme: themeFor(document.documentElement.dataset.theme) } } },
+              'https://giscus.app',
+            );
+          };
+          const themeObserver = new MutationObserver(syncTheme);
+          themeObserver.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['data-theme'],
+          });
+          document.addEventListener('astro:before-swap', () => themeObserver.disconnect(), { once: true });
+        })();
+      </script>
+    </section>
+  )
+}

--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -1,11 +1,14 @@
 ---
-// Giscus comments — opt-in. Everything below (markup *and* script) sits behind
-// the `enabled` check, so a default build ships zero Giscus bytes.
+// Giscus comments — opt-in. Everything below (markup, styles, *and* script)
+// sits behind the `enabled` check, so a default build ships zero Giscus bytes.
 import { GISCUS } from '../consts';
 
 // Guard on the IDs too: a half-filled config would render a widget that can
 // never resolve a discussion.
 const enabled = Boolean(GISCUS.enabled && GISCUS.repo && GISCUS.repoId && GISCUS.categoryId);
+
+// Where to send readers when the widget itself never loads.
+const discussionsUrl = `https://github.com/${GISCUS.repo}/discussions`;
 ---
 
 {
@@ -29,10 +32,45 @@ const enabled = Boolean(GISCUS.enabled && GISCUS.repo && GISCUS.repoId && GISCUS
         data-light-theme={GISCUS.lightTheme}
         data-dark-theme={GISCUS.darkTheme}
       >
+        {/* Shown if the widget never appears — a blocked request, an offline
+            reader, or a repository whose Giscus setup is unfinished. Without
+            it, the reader is left staring at a labelled but permanently empty
+            box with no explanation. */}
+        <p class="comments-fallback" data-giscus-fallback hidden>
+          Comments could not be loaded. Read the thread on{' '}
+          <a href={discussionsUrl} target="_blank" rel="noopener noreferrer">
+            GitHub Discussions ↗
+          </a>
+          .
+        </p>
         <noscript>
           <p class="comments-fallback">Comments require JavaScript. They are hosted on GitHub Discussions.</p>
         </noscript>
       </div>
+
+      {/* `is:inline` for the same reason as the script below: a bundled
+          <style> would land in the shared stylesheet even when comments are
+          disabled, and "zero Giscus bytes" would stop being literally true. */}
+      <style is:inline>
+        {`
+          .comments-mount {
+            max-width: var(--prose-width);
+            margin-top: calc(var(--baseline) * 0.85);
+            border-top: var(--hairline);
+            padding-top: calc(var(--baseline) * 0.85);
+            /* Reserve room so the lazily loaded thread doesn't shift the footer. */
+            min-height: 12rem;
+          }
+
+          .comments-fallback {
+            margin: 0;
+            border: var(--hairline);
+            padding: 1rem 1.25rem;
+            color: var(--color-muted);
+            background: var(--color-surface);
+          }
+        `}
+      </style>
 
       <script is:inline data-astro-rerun>
         // `is:inline` keeps this out of the shared bundle so a disabled config
@@ -46,7 +84,12 @@ const enabled = Boolean(GISCUS.enabled && GISCUS.repo && GISCUS.repoId && GISCUS
           if (!mount || mount.dataset.loaded) return;
 
           const config = mount.dataset;
+          const fallback = mount.querySelector('[data-giscus-fallback]');
           const themeFor = (scheme) => (scheme === 'dark' ? config.darkTheme : config.lightTheme);
+
+          // Long enough that a slow connection is not mistaken for a failure.
+          const FALLBACK_DELAY = 8000;
+          let fallbackTimer;
 
           const load = () => {
             if (mount.dataset.loaded) return;
@@ -68,12 +111,16 @@ const enabled = Boolean(GISCUS.enabled && GISCUS.repo && GISCUS.repoId && GISCUS
             script.setAttribute('data-loading', 'lazy');
             script.setAttribute('data-theme', themeFor(document.documentElement.dataset.theme));
             mount.appendChild(script);
+            fallbackTimer = window.setTimeout(() => {
+              if (!mount.querySelector('iframe.giscus-frame') && fallback) fallback.hidden = false;
+            }, FALLBACK_DELAY);
           };
 
           // Defer the third-party request until the reader is near the thread,
           // so comments never compete with the article for bandwidth.
+          let observer;
           if ('IntersectionObserver' in window) {
-            const observer = new IntersectionObserver(
+            observer = new IntersectionObserver(
               (entries) => {
                 if (!entries.some((entry) => entry.isIntersecting)) return;
                 observer.disconnect();
@@ -85,6 +132,16 @@ const enabled = Boolean(GISCUS.enabled && GISCUS.repo && GISCUS.repoId && GISCUS
           } else {
             load();
           }
+
+          // Giscus renders its own message for a misconfigured repository, so
+          // an iframe appearing at all means the fallback is no longer wanted.
+          const frameObserver = new MutationObserver(() => {
+            if (!mount.querySelector('iframe.giscus-frame')) return;
+            window.clearTimeout(fallbackTimer);
+            if (fallback) fallback.hidden = true;
+            frameObserver.disconnect();
+          });
+          frameObserver.observe(mount, { childList: true, subtree: true });
 
           // Keep the widget in sync with the header toggle. The theme lives on
           // `<html data-theme>`, so watch that attribute rather than the button.
@@ -101,7 +158,20 @@ const enabled = Boolean(GISCUS.enabled && GISCUS.repo && GISCUS.repoId && GISCUS
             attributes: true,
             attributeFilter: ['data-theme'],
           });
-          document.addEventListener('astro:before-swap', () => themeObserver.disconnect(), { once: true });
+
+          // A reader who navigates away before scrolling this far would
+          // otherwise strand these on a detached mount — one set per soft
+          // navigation, with no upper bound over a session.
+          document.addEventListener(
+            'astro:before-swap',
+            () => {
+              themeObserver.disconnect();
+              frameObserver.disconnect();
+              observer?.disconnect();
+              window.clearTimeout(fallbackTimer);
+            },
+            { once: true },
+          );
         })();
       </script>
     </section>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -35,6 +35,59 @@ export const SOCIAL_LINKS: readonly SocialLink[] = [
   { label: 'RSS feed', href: '/rss.xml', icon: 'rss' },
 ];
 
+/** Giscus — GitHub Discussions-backed comments on blog posts.
+ *  See `GISCUS` below; values come from https://giscus.app. */
+export interface GiscusConfig {
+  /** Master switch. While `false`, no Giscus markup or script is emitted. */
+  enabled: boolean;
+  /** Target repository, `owner/name`. Needs public Discussions and the
+   *  giscus GitHub App installed. */
+  repo: string;
+  /** Repository ID from giscus.app (starts with `R_`). */
+  repoId: string;
+  /** Discussion category name, e.g. `Announcements`. */
+  category: string;
+  /** Category ID from giscus.app (starts with `DIC_`). */
+  categoryId: string;
+  /** How a post maps to its discussion. `pathname` is the safest default —
+   *  it survives retitling, unlike `title`. */
+  mapping: 'pathname' | 'url' | 'title' | 'og:title' | 'specific' | 'number';
+  /** Use a strict title match when looking up the discussion. */
+  strict: boolean;
+  /** Show the reaction bar above the comment list. */
+  reactionsEnabled: boolean;
+  /** Put the comment box above (`top`) or below (`bottom`) the thread. */
+  inputPosition: 'top' | 'bottom';
+  /** Giscus UI language, e.g. `en`, `ja`, `fr`. */
+  lang: string;
+  /** Giscus theme used while the site is in light mode. */
+  lightTheme: string;
+  /** Giscus theme used while the site is in dark mode. The widget is told to
+   *  switch live when the header toggle flips. */
+  darkTheme: string;
+}
+
+/** Comments are **off by default** — the theme ships no third-party JavaScript
+ *  unless you ask for it. To turn them on: enable Discussions on your repo,
+ *  install the giscus app (https://github.com/apps/giscus), fill in the IDs
+ *  from https://giscus.app, and set `enabled: true`. */
+export const GISCUS: GiscusConfig = {
+  enabled: false,
+  repo: '',
+  repoId: '',
+  category: 'Announcements',
+  categoryId: '',
+  mapping: 'pathname',
+  strict: true,
+  reactionsEnabled: true,
+  inputPosition: 'bottom',
+  lang: 'en',
+  // Other options include `preferred_color_scheme`, `transparent_dark`,
+  // `noborder_light`, `cobalt`, or a URL to your own theme CSS.
+  lightTheme: 'light',
+  darkTheme: 'dark',
+};
+
 /** Header navigation. `href` is relative to the site root; the configured
  *  `base` is applied automatically via `withBase()`. */
 export const NAV_ITEMS = [

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -3,6 +3,7 @@ import { getCollection, render } from 'astro:content';
 import { Image } from 'astro:assets';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import StructuredData from '../../components/StructuredData.astro';
+import Comments from '../../components/Comments.astro';
 import { withBase } from '../../lib/url';
 import { SITE } from '../../consts';
 
@@ -167,4 +168,6 @@ const schema = [
       </aside>
     )
   }
+
+  <Comments />
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -697,6 +697,25 @@ pre code {
   text-transform: uppercase;
 }
 
+/* Giscus comments (opt-in via GISCUS in src/consts.ts). The widget is an
+   iframe, so the theme only owns the frame around it. */
+.comments-mount {
+  max-width: var(--prose-width);
+  margin-top: calc(var(--baseline) * 0.85);
+  border-top: var(--hairline);
+  padding-top: calc(var(--baseline) * 0.85);
+  /* Reserve room so the lazily loaded thread doesn't shift the footer. */
+  min-height: 12rem;
+}
+
+.comments-fallback {
+  margin: 0;
+  border: var(--hairline);
+  padding: 1rem 1.25rem;
+  color: var(--color-muted);
+  background: var(--color-surface);
+}
+
 .article-toc nav {
   flex-direction: column;
   align-items: flex-start;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -697,25 +697,6 @@ pre code {
   text-transform: uppercase;
 }
 
-/* Giscus comments (opt-in via GISCUS in src/consts.ts). The widget is an
-   iframe, so the theme only owns the frame around it. */
-.comments-mount {
-  max-width: var(--prose-width);
-  margin-top: calc(var(--baseline) * 0.85);
-  border-top: var(--hairline);
-  padding-top: calc(var(--baseline) * 0.85);
-  /* Reserve room so the lazily loaded thread doesn't shift the footer. */
-  min-height: 12rem;
-}
-
-.comments-fallback {
-  margin: 0;
-  border: var(--hairline);
-  padding: 1rem 1.25rem;
-  color: var(--color-muted);
-  background: var(--color-surface);
-}
-
 .article-toc nav {
   flex-direction: column;
   align-items: flex-start;


### PR DESCRIPTION
## What

Optional [Giscus](https://giscus.app) comments on blog posts, opt-in through `src/consts.ts`.

Closes #15

## Why

Comments are the most-asked-for blog feature, and Giscus keeps the theme's zero-backend promise — the thread lives in GitHub Discussions. The constraint was that it must not cost anything for the majority of users who leave it off.

## How

- **`src/consts.ts`** — a `GISCUS` object (`GiscusConfig`) with `enabled: false` by default, plus `repo` / `repoId` / `category` / `categoryId` / `mapping` / `strict` / `reactionsEnabled` / `inputPosition` / `lang` / `lightTheme` / `darkTheme`. Every field carries a doc comment.
- **`src/components/Comments.astro`** — rendered from `src/pages/blog/[slug].astro`. The whole component (markup *and* script) sits behind the `enabled` check, and the script is `is:inline` rather than bundled, so a disabled build emits literally nothing. It also guards on the IDs, since a half-filled config would render a widget that can never resolve a discussion.
- **Lazy loading** — an `IntersectionObserver` with a `400px` root margin defers `giscus.app/client.js` until the reader scrolls near the thread. `min-height` on the mount reserves space so the footer doesn't jump.
- **Theme sync** — a `MutationObserver` on `<html data-theme>` posts `setConfig` to the Giscus iframe, so the widget follows the header toggle live. Watching the attribute rather than the toggle button means it also picks up changes from other sources.
- **View Transitions** — follows the pattern already established in `search.astro`: `is:inline` + `data-astro-rerun` + an IIFE, with config passed via data attributes (`define:vars` would strip `data-astro-rerun`). The `MutationObserver` disconnects on `astro:before-swap`.

## Verification

`npm run check` 0 errors, `npm run build` succeeds.

**Zero bytes when disabled** — with the shipped default config, `grep -ril giscus dist` returns nothing.

**Enabled path**, driven in headless Chrome against a production build (temporary test IDs):

```
before scroll — giscus requested: false     ← lazy, no third-party cost above the fold
after scroll  — giscus requested: true
mount data-loaded: 1
script data-theme: dark                     ← matches the active scheme at load
html data-theme after toggle: light         ← toggle works, no errors from the sync path
after soft nav back — mount loaded: 1       ← re-initializes after a view transition
page errors: only giscus's own "giscus is not installed on this repository"
```

That last line is expected — the test IDs point at a repo without the Giscus app, so the widget itself could not render a live thread. End-to-end confirmation needs a repo with Discussions enabled and the app installed; the loading, theming, and soft-navigation plumbing is what's verified above.

## Screenshots

No visual change to the default build — the section only exists when comments are enabled.

## Checklist

- [x] `npm run check` passes (0 errors, 4 pre-existing hints)
- [x] `npm run build` succeeds
- [x] Verified in both light and dark mode (theme sync driven in headless Chrome)
- [x] New config options documented in `src/consts.ts` comments and the README
- [x] Opt-in, off by default
