### PR TITLE
feat: i18n Phase 1 — localizable UI strings driven by SITE.locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,10 +56,18 @@ written with that in mind — each one names the files it touches.
 
 - **`minutesRead` is now a number**, not a preformatted `"3 min read"` string.
   `reading-time`'s own text is hard-coded English and would have survived every
-  `SITE.locale` change; templates render it through `t('post.readingTime')`
-  instead. If you read `remarkPluginFrontmatter.minutesRead` in a template of
-  your own, wrap it the same way. Incremental builds cache the old value —
-  delete `.astro/` once after upgrading.
+  `SITE.locale` change; templates render it through the `readingTime()` helper
+  in `src/i18n/` instead. If you read `remarkPluginFrontmatter.minutesRead` in a
+  template of your own, route it through that helper too — it tolerates either
+  shape.
+
+  The Content Layer keeps rendered frontmatter in
+  `node_modules/.astro/data-store.json`, and changing a remark plugin does not
+  invalidate it, so the first build after upgrading may still serve the old
+  value. Delete `node_modules/.astro/` once — clearing the repo-root `.astro/`
+  is *not* enough, it only holds generated types. The helper degrades
+  gracefully in the meantime (you would otherwise see `3 min read min read`
+  after upgrading, or a bare `3` after downgrading).
 - Site identity (title, description, RSS description, share image, author,
   footer text, nav items) is centralized in `src/consts.ts`.
 - README rewritten: badge header, light/dark preview screenshots, and expanded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ written with that in mind — each one names the files it touches.
 - Sticky top bar on scroll.
 - Community health files — issue forms, a pull request template,
   `CONTRIBUTING.md`, and this changelog.
+- **Localizable UI strings.** Every string the theme itself renders now comes
+  from a typed dictionary in `src/i18n/`, selected by a new `SITE.locale`.
+  One line also drives `<html lang>`, `og:locale`, `Intl` date formatting, and
+  the RSS `<language>` element. `en` and `ja` ship with the theme; the
+  dictionary covers UI chrome only, so the placeholder prose on the home and
+  about pages stays in those `.astro` files. Nav entries take a `labelKey`
+  (dictionary) or a literal `label`, and the type requires exactly one.
 - **Optional Giscus comments** on blog posts, configured through `GISCUS` in
   `src/consts.ts` and **off by default** — a disabled build emits no Giscus
   markup, styles, or script at all. When enabled, the widget loads only once the
@@ -47,6 +54,12 @@ written with that in mind — each one names the files it touches.
 
 ### Changed
 
+- **`minutesRead` is now a number**, not a preformatted `"3 min read"` string.
+  `reading-time`'s own text is hard-coded English and would have survived every
+  `SITE.locale` change; templates render it through `t('post.readingTime')`
+  instead. If you read `remarkPluginFrontmatter.minutesRead` in a template of
+  your own, wrap it the same way. Incremental builds cache the old value —
+  delete `.astro/` once after upgrading.
 - Site identity (title, description, RSS description, share image, author,
   footer text, nav items) is centralized in `src/consts.ts`.
 - README rewritten: badge header, light/dark preview screenshots, and expanded

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A calm neutral base, a single configurable accent color, generous whitespace, an
 - **One-line accent color** — retune the whole theme by changing a single CSS variable (`--color-accent`).
 - **Light + dark mode** — respects `prefers-color-scheme` and remembers a manual toggle (no flash on load).
 - **Self-hosted type** — Fraunces (display), Public Sans (body), and JetBrains Mono (code) via `@fontsource`, no external font CDN.
+- **i18n-ready** — every UI string lives in a typed dictionary under `src/i18n/`; one `SITE.locale` line switches the chrome, date formats, `<html lang>`, and the RSS language. `en` and `ja` included.
 - **Tags** — per-tag archive pages at `/blog/tags/[tag]`.
 - **Pagination** — blog and tag archives paginate every 10 posts with hairline prev/next links.
 - **Static search** — zero-backend full-text search at `/search` powered by [Pagefind](https://pagefind.app/), indexed at build time.
@@ -135,6 +136,70 @@ export const SOCIAL_LINKS: readonly SocialLink[] = [
 ```
 
 Built-in icons: `github`, `x`, `linkedin`, `rss`, `email`. Site-root paths (like `/rss.xml`) get the configured `base` applied automatically; `mailto:` and full URLs are used as-is.
+
+### Language
+
+Set `SITE.locale` in `src/consts.ts` to a BCP 47 tag. One line switches every
+string the theme renders, plus `<html lang>`, `og:locale`, date formatting, and
+the RSS `<language>` element — no template edits:
+
+```ts
+export const SITE = {
+  locale: 'ja', // ← 'en' and 'ja' ship with the theme
+  // ...
+};
+```
+
+Dates go through `Intl.DateTimeFormat`, so field order follows the locale too
+(`March 9, 2026` → `2026年3月9日`).
+
+#### Adding a language
+
+1. Copy `src/i18n/ja.ts` to `src/i18n/<tag>.ts` and translate the values. The
+   file is typed as `UIStrings`, so a missing or misspelled key is a build
+   error rather than a silent fallback to English.
+2. Register it in `src/i18n/index.ts`:
+
+   ```ts
+   import { fr } from './fr';
+
+   export const DICTIONARIES: Record<string, UIStrings> = { en, ja, fr };
+   ```
+
+3. Set `SITE.locale` to the new tag.
+
+`src/i18n/en.ts` is the reference dictionary and defines the shape — add new
+keys there first. It holds **UI chrome only** (navigation, pagination, button
+and section labels, aria labels, the 404 copy): roughly 60 short strings, so a
+new locale is a small pull request. The placeholder prose on the home and about
+pages stays in those `.astro` files, where you would edit it anyway.
+
+Regional variants fall back to their base language's strings (`en-GB` uses the
+`en` dictionary) while keeping their own date format, so they only need their
+own file if the wording actually differs.
+
+Nav labels come from the same dictionary via `labelKey`. A page you add yourself
+can skip the dictionary and use a literal `label` instead — the type requires
+exactly one of the two:
+
+```ts
+export const NAV_ITEMS: readonly NavItem[] = [
+  { href: '/', labelKey: 'nav.home' },
+  { href: '/uses/', label: 'Uses' },
+];
+```
+
+> [!NOTE]
+> **Non-Latin scripts and generated images.** The OG image route bundles
+> **Latin subsets** of Fraunces and Public Sans to keep builds light, and Satori
+> draws any missing glyph as an empty box. Post titles in a non-Latin script
+> need a font that covers it — install e.g. `@fontsource/noto-sans-jp` and point
+> `src/pages/og/[collection]/[slug].png.ts` at it. (The theme's own labels in
+> those images stay Latin for this reason.)
+>
+> Pagefind indexes by the document's `lang`, so `<html lang="ja">` gets proper
+> Japanese segmentation. Its Default UI strings ("Search", "Clear") are
+> translated for many languages but not all — check yours.
 
 ### Comments (optional)
 
@@ -252,9 +317,10 @@ heroImage: ./hero.png            # optional — relative image
 
 ```
 src/
-  consts.ts          # site name, description, nav, footer
+  consts.ts          # site name, description, locale, nav, footer
   content/           # works/ and blog/ Markdown & MDX entries
   content.config.ts  # collection schemas (Content Layer API)
+  i18n/              # UI dictionaries (en, ja) + t() and formatDate()
   layouts/           # BaseLayout (head, nav, theme toggle)
   pages/             # routes: /, /about, /works, /blog, tags, rss.xml
   styles/            # global.css design tokens

--- a/remark-reading-time.mjs
+++ b/remark-reading-time.mjs
@@ -1,12 +1,18 @@
 import { toString } from 'mdast-util-to-string';
 import getReadingTime from 'reading-time';
 
-// Injects `minutesRead` (e.g. "3 min read") into every Markdown/MDX entry's
+// Injects `minutesRead` — a *number* — into every Markdown/MDX entry's
 // frontmatter, exposed at render time via `remarkPluginFrontmatter`.
+//
+// The plugin deliberately does not format the value: `reading-time`'s own
+// `.text` is hard-coded English ("3 min read"), which would survive every
+// `SITE.locale` change. Templates render it through `t('post.readingTime')`.
 export function remarkReadingTime() {
   return (tree, { data }) => {
     const textOnPage = toString(tree);
     const readingTime = getReadingTime(textOnPage);
-    data.astro.frontmatter.minutesRead = readingTime.text;
+    // `Math.ceil`, matching what `reading-time`'s own `.text` reported before,
+    // with a floor of 1 so a one-line note never reads "0 min".
+    data.astro.frontmatter.minutesRead = Math.max(1, Math.ceil(readingTime.minutes));
   };
 }

--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -2,6 +2,7 @@
 // Giscus comments — opt-in. Everything below (markup, styles, *and* script)
 // sits behind the `enabled` check, so a default build ships zero Giscus bytes.
 import { GISCUS } from '../consts';
+import { t } from '../i18n';
 
 // Guard on the IDs too: a half-filled config would render a widget that can
 // never resolve a discussion.
@@ -15,7 +16,7 @@ const discussionsUrl = `https://github.com/${GISCUS.repo}/discussions`;
   enabled && (
     <section class="section post-nav-section comments-section" aria-labelledby="comments-heading" data-pagefind-ignore>
       <p class="eyebrow" id="comments-heading">
-        Comments
+        {t('comments.eyebrow')}
       </p>
       <div
         class="comments-mount"
@@ -36,15 +37,9 @@ const discussionsUrl = `https://github.com/${GISCUS.repo}/discussions`;
             reader, or a repository whose Giscus setup is unfinished. Without
             it, the reader is left staring at a labelled but permanently empty
             box with no explanation. */}
-        <p class="comments-fallback" data-giscus-fallback hidden>
-          Comments could not be loaded. Read the thread on{' '}
-          <a href={discussionsUrl} target="_blank" rel="noopener noreferrer">
-            GitHub Discussions ↗
-          </a>
-          .
-        </p>
+        <p class="comments-fallback" data-giscus-fallback hidden set:html={t('comments.failed', { url: discussionsUrl })} />
         <noscript>
-          <p class="comments-fallback">Comments require JavaScript. They are hosted on GitHub Discussions.</p>
+          <p class="comments-fallback">{t('comments.noscript')}</p>
         </noscript>
       </div>
 

--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -8,8 +8,12 @@ import { t } from '../i18n';
 // never resolve a discussion.
 const enabled = Boolean(GISCUS.enabled && GISCUS.repo && GISCUS.repoId && GISCUS.categoryId);
 
-// Where to send readers when the widget itself never loads.
-const discussionsUrl = `https://github.com/${GISCUS.repo}/discussions`;
+// Where to send readers when the widget itself never loads. The anchor is
+// assembled here rather than in the dictionary so the URL goes through
+// `encodeURI` — `GISCUS.repo` is user-supplied config, and a stray quote would
+// otherwise break out of the `href`.
+const discussionsUrl = encodeURI(`https://github.com/${GISCUS.repo}/discussions`);
+const discussionsLink = `<a href="${discussionsUrl}" target="_blank" rel="noopener noreferrer">${t('comments.failedLink')}</a>`;
 ---
 
 {
@@ -37,7 +41,7 @@ const discussionsUrl = `https://github.com/${GISCUS.repo}/discussions`;
             reader, or a repository whose Giscus setup is unfinished. Without
             it, the reader is left staring at a labelled but permanently empty
             box with no explanation. */}
-        <p class="comments-fallback" data-giscus-fallback hidden set:html={t('comments.failed', { url: discussionsUrl })} />
+        <p class="comments-fallback" data-giscus-fallback hidden set:html={t('comments.failed', { link: discussionsLink })} />
         <noscript>
           <p class="comments-fallback">{t('comments.noscript')}</p>
         </noscript>

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,5 +1,6 @@
 ---
 import type { Page } from 'astro';
+import { t } from '../i18n';
 
 interface Props {
   page: Page<unknown>;
@@ -19,12 +20,12 @@ const next = withSlash(page.url.next);
 
 {
   page.lastPage > 1 && (
-    <nav class="pagination" aria-label="Pagination">
-      {prev ? <a href={prev} rel="prev">← Newer</a> : <span aria-hidden="true" />}
+    <nav class="pagination" aria-label={t('pagination.label')}>
+      {prev ? <a href={prev} rel="prev">{t('pagination.newer')}</a> : <span aria-hidden="true" />}
       <span class="pagination-status">
-        Page {page.currentPage} of {page.lastPage}
+        {t('pagination.status', { current: page.currentPage, total: page.lastPage })}
       </span>
-      {next ? <a href={next} rel="next">Older →</a> : <span aria-hidden="true" />}
+      {next ? <a href={next} rel="next">{t('pagination.older')}</a> : <span aria-hidden="true" />}
     </nav>
   )
 }

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -4,6 +4,7 @@
 // `currentColor`, so they follow the light/dark palettes automatically.
 import { SOCIAL_LINKS, type SocialIcon } from '../consts';
 import { withBase } from '../lib/url';
+import { t } from '../i18n';
 
 const ICONS: Record<SocialIcon, string> = {
   github:
@@ -21,7 +22,7 @@ const isInternal = (href: string) => href.startsWith('/');
 
 {
   SOCIAL_LINKS.length > 0 && (
-    <ul class="social-links" aria-label="Social links">
+    <ul class="social-links" aria-label={t('social.label')}>
       {SOCIAL_LINKS.map((link) => (
         <li>
           <a

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,7 +1,14 @@
 // Site-wide settings. Edit this file to rebrand the theme — every page,
 // the RSS feed, and Open Graph tags read from here.
 
+import type { UIKey } from './i18n/en';
+
 export const SITE = {
+  /** BCP 47 language tag. Picks the UI dictionary in `src/i18n/`, and sets
+   *  `<html lang>`, date formatting, and the RSS feed language. Dictionaries
+   *  ship for `en` and `ja`; regional variants like `en-GB` reuse the base
+   *  language's strings while keeping their own date format. */
+  locale: 'en',
   /** Site name — used in the header brand, <title>, and og:site_name. */
   title: 'Astro Keel',
   /** Default meta description for pages that don't set their own. */
@@ -38,7 +45,7 @@ export const SOCIAL_LINKS: readonly SocialLink[] = [
 /** Giscus — GitHub Discussions-backed comments on blog posts.
  *  See `GISCUS` below; values come from https://giscus.app. */
 export interface GiscusConfig {
-  /** Master switch. While `false`, no Giscus markup or script is emitted. */
+  /** Master switch. While `false`, no Giscus markup, CSS, or script is emitted. */
   enabled: boolean;
   /** Target repository, `owner/name`. Needs public Discussions and the
    *  giscus GitHub App installed. */
@@ -88,12 +95,18 @@ export const GISCUS: GiscusConfig = {
   darkTheme: 'dark',
 };
 
+export type NavItem =
+  | { href: string; label: string; labelKey?: never }
+  | { href: string; labelKey: UIKey; label?: never };
+
 /** Header navigation. `href` is relative to the site root; the configured
- *  `base` is applied automatically via `withBase()`. */
-export const NAV_ITEMS = [
-  { href: '/', label: 'Home' },
-  { href: '/about/', label: 'About' },
-  { href: '/works/', label: 'Works' },
-  { href: '/blog/', label: 'Blog' },
-  { href: '/search/', label: 'Search' },
-] as const;
+ *  `base` is applied automatically via `withBase()`. The bundled entries
+ *  localize through the UI dictionary; give a page you add yourself a literal
+ *  `label` instead — one of the two is required. */
+export const NAV_ITEMS: readonly NavItem[] = [
+  { href: '/', labelKey: 'nav.home' },
+  { href: '/about/', labelKey: 'nav.about' },
+  { href: '/works/', labelKey: 'nav.works' },
+  { href: '/blog/', labelKey: 'nav.blog' },
+  { href: '/search/', labelKey: 'nav.search' },
+];

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,11 +1,17 @@
 // English UI dictionary — the reference translation.
 //
+// **Scope: UI chrome only.** Navigation, pagination, section labels, button and
+// link labels, aria labels, generated strings, and the theme-owned 404 page.
+// Placeholder prose on the home and about pages is *not* here: it lives in the
+// `.astro` files, where you would edit it anyway. Keeping the split means a new
+// locale is ~60 short strings rather than a rewrite of the demo copy.
+//
 // This file also defines the *shape* every other dictionary must match, so add
 // a key here first, then to each locale under `src/i18n/`. Keys are flat and
 // dotted; `{name}` placeholders are filled in by `t()`.
 //
-// A handful of values carry inline markup (`<code>`); those are rendered with
-// `set:html`. They are theme-authored, never user input.
+// Two values carry inline `<code>` markup and are rendered with `set:html`.
+// They are theme-authored, never user input.
 //
 // Note: values are deliberately *not* `as const` — widening them to `string`
 // is what lets other locales satisfy `UIStrings`.
@@ -29,32 +35,17 @@ export const en = {
   'pagination.older': 'Older →',
   'pagination.status': 'Page {current} of {total}',
 
-  // Home
-  'home.description': 'A minimal portfolio and writing theme for careful technical work.',
-  'home.eyebrow': 'Portfolio / writing / systems notes',
-  'home.heading': 'Structural minimalism for careful digital work.',
-  'home.lead':
-    'Astro Keel gives projects, essays, and professional notes a disciplined frame: editorial type, measured rhythm, and a single accent carried through fine structural rules.',
+  // Home — labels and links only; the page's own copy lives in index.astro
   'home.primaryLinks': 'Primary links',
   'home.viewWorks': 'View works',
   'home.readNotes': 'Read notes',
   'home.overviewLabel': 'Theme overview',
-  'home.principlesEyebrow': 'Principles',
-  'home.principlesHeading': 'Readable first, decorative last.',
-  'home.principleRhythmTitle': 'Baseline rhythm',
-  'home.principleRhythmBody': 'Vertical spacing follows a steady cadence for long-form reading.',
-  'home.principleContentTitle': 'Typed content',
-  'home.principleContentBody': 'Collections are prepared for project case studies and durable notes.',
-  'home.principleLinesTitle': 'Keel lines',
-  'home.principleLinesBody': 'Fine rules create structure without relying on decorative effects.',
   'home.latestWorksEyebrow': 'Latest works',
-  'home.latestWorksHeading': 'Built records.',
   'home.allWorks': 'All works',
+  'home.workTech': '{title} technology',
   'home.worksEmpty':
     'Add works under <code>src/content/works</code> to surface the latest projects here.',
-  'home.workTech': '{title} technology',
   'home.latestBlogEyebrow': 'Latest blog',
-  'home.latestBlogHeading': 'Field notes.',
   'home.allPosts': 'All posts',
   'home.postsEmpty':
     'Add blog entries under <code>src/content/blog</code> to surface the latest notes here.',
@@ -62,16 +53,13 @@ export const en = {
   // Blog index
   'blog.title': 'Blog',
   'blog.titlePaged': 'Blog · Page {page}',
-  'blog.description': 'Notes and writing — {site}, a minimal portfolio and blog theme for Astro.',
   'blog.eyebrow': 'Blog',
-  'blog.heading': 'Notes, essays, and release logs.',
-  'blog.lead':
-    'The blog collection supports tags, descriptions, draft filtering, publish dates, and optional hero images.',
   'blog.listLabel': 'Blog posts',
   'blog.tagsEyebrow': 'Tags',
   'blog.tagsNavLabel': 'Blog tags',
 
-  // Tag archive
+  // Tag archive — every string here is generated from the tag, so it stays
+  // in the dictionary even though it reads like page copy.
   'tag.title': 'Posts tagged “{tag}”',
   'tag.titlePaged': 'Posts tagged “{tag}” · Page {page}',
   'tag.description': 'Blog posts tagged {tag} on {site}.',
@@ -84,6 +72,7 @@ export const en = {
 
   // Blog post
   'post.eyebrow': 'Blog',
+  'post.readingTime': '{minutes} min read',
   'post.tocLabel': 'Table of contents',
   'post.contentsEyebrow': 'Contents',
   'post.adjacentLabel': 'Adjacent posts',
@@ -93,59 +82,36 @@ export const en = {
   'post.breadcrumbHome': 'Home',
   'post.breadcrumbBlog': 'Blog',
 
-  // Works index
-  'works.title': 'Works',
-  'works.description': 'Selected projects and case studies — {site}.',
-  'works.eyebrow': 'Works',
-  'works.heading': 'Selected projects and case studies.',
-  'works.lead':
-    'The works collection is typed for descriptions, technology lists, external links, repositories, thumbnails, ordering, and publish dates.',
-  'works.listLabel': 'Selected works',
+  // Comments (rendered only when GISCUS.enabled)
+  'comments.eyebrow': 'Comments',
+  // `{url}` is the repository's discussions page; the link markup lives in the
+  // string so a translation can put it wherever the sentence needs it.
+  'comments.failed':
+    'Comments could not be loaded. Read the thread on <a href="{url}" target="_blank" rel="noopener noreferrer">GitHub Discussions ↗</a>.',
+  'comments.noscript': 'Comments require JavaScript. They are hosted on GitHub Discussions.',
 
-  // Work detail
+  // Works
+  'works.title': 'Works',
+  'works.eyebrow': 'Works',
+  'works.listLabel': 'Selected works',
   'work.eyebrow': 'Work',
   'work.visit': 'Visit project',
   'work.repository': 'View repository',
   'work.stackEyebrow': 'Stack',
 
-  // About
+  // About — section labels only; the biography copy lives in about/index.astro
   'about.title': 'About',
-  'about.description': 'About the author behind this {site} site.',
   'about.eyebrow': 'About',
-  'about.heading': 'A measured profile for the person behind the work.',
-  'about.lead':
-    'This page is shaped for a concise biography, a working philosophy, and the handful of details that help readers understand how you think.',
-  'about.profileEyebrow': 'Profile',
-  'about.profileHeading': 'Quiet systems, clear writing, durable interfaces.',
-  'about.profileBody1':
-    'I work across product strategy, interface systems, and technical writing. The common thread is structure: making complex material easier to scan, trust, and maintain.',
-  'about.profileBody2':
-    'Astro Keel leaves room for this kind of context without forcing a loud personal brand. Replace this placeholder with a specific background, current role, and the constraints that shape your work.',
   'about.ledgerLabel': 'Experience summary',
-  'about.focusTitle': 'Current focus',
-  'about.focusBody': 'Designing lean content systems, portfolio surfaces, and editorial product pages.',
-  'about.backgroundTitle': 'Background',
-  'about.backgroundBody':
-    'Experience spanning frontend implementation, design systems, and writing for technical audiences.',
-  'about.contactTitle': 'Contact',
-  'about.contactBody':
-    'Use this section for availability, collaboration preferences, or a direct contact route.',
-  'about.methodEyebrow': 'Method',
-  'about.methodHeading': 'Structure before surface.',
-  'about.methodBody':
-    'The theme treats the page like a working document: hierarchy first, rhythm second, visual signature third. Fine rules, generous spacing, and type contrast carry the identity without competing with the content.',
 
   // Search
   'search.title': 'Search',
-  'search.description': 'Search posts and works — {site}.',
   'search.eyebrow': 'Search',
-  'search.heading': 'Find posts and works.',
-  'search.lead': 'Fully static search powered by Pagefind — indexed at build time, no backend required.',
   'search.sectionLabel': 'Site search',
   'search.fallback':
     'The search index is generated at build time. Run <code>npm run build</code> and preview the site to try it — it is not available on the dev server.',
 
-  // 404
+  // 404 — a theme-owned page, so its copy belongs here
   'notFound.title': 'Page not found',
   'notFound.description': 'The page you were looking for does not exist.',
   'notFound.eyebrow': '404 — Not found',
@@ -156,10 +122,6 @@ export const en = {
   'notFound.home': 'Back home',
   'notFound.blog': 'Read the blog',
   'notFound.works': 'Browse works',
-
-  // Generated Open Graph images
-  'og.blog': 'Blog',
-  'og.work': 'Work',
 };
 
 /** The shape every dictionary must implement. */

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,0 +1,169 @@
+// English UI dictionary — the reference translation.
+//
+// This file also defines the *shape* every other dictionary must match, so add
+// a key here first, then to each locale under `src/i18n/`. Keys are flat and
+// dotted; `{name}` placeholders are filled in by `t()`.
+//
+// A handful of values carry inline markup (`<code>`); those are rendered with
+// `set:html`. They are theme-authored, never user input.
+//
+// Note: values are deliberately *not* `as const` — widening them to `string`
+// is what lets other locales satisfy `UIStrings`.
+
+export const en = {
+  // Header, footer, and other chrome
+  'nav.home': 'Home',
+  'nav.about': 'About',
+  'nav.works': 'Works',
+  'nav.blog': 'Blog',
+  'nav.search': 'Search',
+  'nav.label': 'Main navigation',
+  'nav.brandHome': '{site} home',
+  'theme.toggle': 'Toggle color theme',
+  'footer.notes': 'Notes',
+  'social.label': 'Social links',
+
+  // Pagination
+  'pagination.label': 'Pagination',
+  'pagination.newer': '← Newer',
+  'pagination.older': 'Older →',
+  'pagination.status': 'Page {current} of {total}',
+
+  // Home
+  'home.description': 'A minimal portfolio and writing theme for careful technical work.',
+  'home.eyebrow': 'Portfolio / writing / systems notes',
+  'home.heading': 'Structural minimalism for careful digital work.',
+  'home.lead':
+    'Astro Keel gives projects, essays, and professional notes a disciplined frame: editorial type, measured rhythm, and a single accent carried through fine structural rules.',
+  'home.primaryLinks': 'Primary links',
+  'home.viewWorks': 'View works',
+  'home.readNotes': 'Read notes',
+  'home.overviewLabel': 'Theme overview',
+  'home.principlesEyebrow': 'Principles',
+  'home.principlesHeading': 'Readable first, decorative last.',
+  'home.principleRhythmTitle': 'Baseline rhythm',
+  'home.principleRhythmBody': 'Vertical spacing follows a steady cadence for long-form reading.',
+  'home.principleContentTitle': 'Typed content',
+  'home.principleContentBody': 'Collections are prepared for project case studies and durable notes.',
+  'home.principleLinesTitle': 'Keel lines',
+  'home.principleLinesBody': 'Fine rules create structure without relying on decorative effects.',
+  'home.latestWorksEyebrow': 'Latest works',
+  'home.latestWorksHeading': 'Built records.',
+  'home.allWorks': 'All works',
+  'home.worksEmpty':
+    'Add works under <code>src/content/works</code> to surface the latest projects here.',
+  'home.workTech': '{title} technology',
+  'home.latestBlogEyebrow': 'Latest blog',
+  'home.latestBlogHeading': 'Field notes.',
+  'home.allPosts': 'All posts',
+  'home.postsEmpty':
+    'Add blog entries under <code>src/content/blog</code> to surface the latest notes here.',
+
+  // Blog index
+  'blog.title': 'Blog',
+  'blog.titlePaged': 'Blog · Page {page}',
+  'blog.description': 'Notes and writing — {site}, a minimal portfolio and blog theme for Astro.',
+  'blog.eyebrow': 'Blog',
+  'blog.heading': 'Notes, essays, and release logs.',
+  'blog.lead':
+    'The blog collection supports tags, descriptions, draft filtering, publish dates, and optional hero images.',
+  'blog.listLabel': 'Blog posts',
+  'blog.tagsEyebrow': 'Tags',
+  'blog.tagsNavLabel': 'Blog tags',
+
+  // Tag archive
+  'tag.title': 'Posts tagged “{tag}”',
+  'tag.titlePaged': 'Posts tagged “{tag}” · Page {page}',
+  'tag.description': 'Blog posts tagged {tag} on {site}.',
+  'tag.eyebrow': 'Tag',
+  'tag.lead': 'Notes collected under the {tag} tag.',
+  'tag.listLabel': '{tag} posts',
+  'tag.moreTagsEyebrow': 'More tags',
+  'tag.otherTagsNavLabel': 'Other blog tags',
+  'tag.allPosts': 'All posts',
+
+  // Blog post
+  'post.eyebrow': 'Blog',
+  'post.tocLabel': 'Table of contents',
+  'post.contentsEyebrow': 'Contents',
+  'post.adjacentLabel': 'Adjacent posts',
+  'post.previous': 'Previous',
+  'post.next': 'Next',
+  'post.relatedEyebrow': 'Related',
+  'post.breadcrumbHome': 'Home',
+  'post.breadcrumbBlog': 'Blog',
+
+  // Works index
+  'works.title': 'Works',
+  'works.description': 'Selected projects and case studies — {site}.',
+  'works.eyebrow': 'Works',
+  'works.heading': 'Selected projects and case studies.',
+  'works.lead':
+    'The works collection is typed for descriptions, technology lists, external links, repositories, thumbnails, ordering, and publish dates.',
+  'works.listLabel': 'Selected works',
+
+  // Work detail
+  'work.eyebrow': 'Work',
+  'work.visit': 'Visit project',
+  'work.repository': 'View repository',
+  'work.stackEyebrow': 'Stack',
+
+  // About
+  'about.title': 'About',
+  'about.description': 'About the author behind this {site} site.',
+  'about.eyebrow': 'About',
+  'about.heading': 'A measured profile for the person behind the work.',
+  'about.lead':
+    'This page is shaped for a concise biography, a working philosophy, and the handful of details that help readers understand how you think.',
+  'about.profileEyebrow': 'Profile',
+  'about.profileHeading': 'Quiet systems, clear writing, durable interfaces.',
+  'about.profileBody1':
+    'I work across product strategy, interface systems, and technical writing. The common thread is structure: making complex material easier to scan, trust, and maintain.',
+  'about.profileBody2':
+    'Astro Keel leaves room for this kind of context without forcing a loud personal brand. Replace this placeholder with a specific background, current role, and the constraints that shape your work.',
+  'about.ledgerLabel': 'Experience summary',
+  'about.focusTitle': 'Current focus',
+  'about.focusBody': 'Designing lean content systems, portfolio surfaces, and editorial product pages.',
+  'about.backgroundTitle': 'Background',
+  'about.backgroundBody':
+    'Experience spanning frontend implementation, design systems, and writing for technical audiences.',
+  'about.contactTitle': 'Contact',
+  'about.contactBody':
+    'Use this section for availability, collaboration preferences, or a direct contact route.',
+  'about.methodEyebrow': 'Method',
+  'about.methodHeading': 'Structure before surface.',
+  'about.methodBody':
+    'The theme treats the page like a working document: hierarchy first, rhythm second, visual signature third. Fine rules, generous spacing, and type contrast carry the identity without competing with the content.',
+
+  // Search
+  'search.title': 'Search',
+  'search.description': 'Search posts and works — {site}.',
+  'search.eyebrow': 'Search',
+  'search.heading': 'Find posts and works.',
+  'search.lead': 'Fully static search powered by Pagefind — indexed at build time, no backend required.',
+  'search.sectionLabel': 'Site search',
+  'search.fallback':
+    'The search index is generated at build time. Run <code>npm run build</code> and preview the site to try it — it is not available on the dev server.',
+
+  // 404
+  'notFound.title': 'Page not found',
+  'notFound.description': 'The page you were looking for does not exist.',
+  'notFound.eyebrow': '404 — Not found',
+  'notFound.heading': 'This page drifted off course.',
+  'notFound.lead':
+    'The address may have moved, or it never existed. The keel lines below lead back to steady water.',
+  'notFound.linksLabel': 'Recovery links',
+  'notFound.home': 'Back home',
+  'notFound.blog': 'Read the blog',
+  'notFound.works': 'Browse works',
+
+  // Generated Open Graph images
+  'og.blog': 'Blog',
+  'og.work': 'Work',
+};
+
+/** The shape every dictionary must implement. */
+export type UIStrings = typeof en;
+
+/** Every valid translation key. */
+export type UIKey = keyof UIStrings;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -84,10 +84,11 @@ export const en = {
 
   // Comments (rendered only when GISCUS.enabled)
   'comments.eyebrow': 'Comments',
-  // `{url}` is the repository's discussions page; the link markup lives in the
-  // string so a translation can put it wherever the sentence needs it.
-  'comments.failed':
-    'Comments could not be loaded. Read the thread on <a href="{url}" target="_blank" rel="noopener noreferrer">GitHub Discussions ↗</a>.',
+  // `{link}` is a whole anchor element, built in Comments.astro — a translation
+  // decides where in the sentence it lands, and the URL never has to be
+  // interpolated into the dictionary value.
+  'comments.failed': 'Comments could not be loaded. Read the thread on {link}.',
+  'comments.failedLink': 'GitHub Discussions ↗',
   'comments.noscript': 'Comments require JavaScript. They are hosted on GitHub Discussions.',
 
   // Works

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -40,6 +40,20 @@ export const t = (key: UIKey, params?: Record<string, string | number>): string 
   );
 };
 
+/**
+ * Render a post's reading time.
+ *
+ * `remarkPluginFrontmatter` is untyped, and the Content Layer store in
+ * `node_modules/.astro/` survives an upgrade — so `minutesRead` may still be
+ * the preformatted `"3 min read"` string this theme used to emit. Interpolating
+ * that into `post.readingTime` would print "3 min read min read"; going the
+ * other way would print a bare "3". Passing an unexpected value straight
+ * through degrades to readable-but-untranslated text until the store is
+ * rebuilt, instead of showing either kind of garbage.
+ */
+export const readingTime = (minutesRead: unknown): string =>
+  typeof minutesRead === 'number' ? t('post.readingTime', { minutes: minutesRead }) : String(minutesRead ?? '');
+
 /** Format a publish date in the active locale. `long` spells the month out;
  *  `short` abbreviates it. Both are locale-aware, including field order. */
 export const formatDate = (date: Date, style: 'long' | 'short' = 'long'): string =>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,55 @@
+// UI localization. Every user-facing string the theme itself renders comes from
+// a dictionary here; `SITE.locale` in `src/consts.ts` picks which one, and also
+// drives `<html lang>`, date formatting, and the RSS feed language.
+//
+// To add a locale: copy `ja.ts`, translate the values, and register it in
+// `DICTIONARIES` below. Nothing else needs editing.
+import { SITE } from '../consts';
+import { en, type UIKey, type UIStrings } from './en';
+import { ja } from './ja';
+
+export type { UIKey, UIStrings };
+
+/** Fallback used when `SITE.locale` has no dictionary. */
+export const DEFAULT_LOCALE = 'en';
+
+/** Registered dictionaries, keyed by BCP 47 language tag. */
+export const DICTIONARIES: Record<string, UIStrings> = { en, ja };
+
+/** The active locale, straight from `SITE.locale`. Also the value passed to
+ *  `Intl`, `<html lang>`, and the RSS `<language>` element. */
+export const locale: string = SITE.locale;
+
+// `en-GB` falls back to the `en` dictionary while still formatting dates as
+// `en-GB` — a regional variant rarely needs its own copy of every string.
+const resolveDictionary = (tag: string): UIStrings =>
+  DICTIONARIES[tag] ?? DICTIONARIES[tag.split('-')[0]] ?? DICTIONARIES[DEFAULT_LOCALE];
+
+/** The active dictionary. Exported mainly for tests and debugging — prefer `t()`. */
+export const strings: UIStrings = resolveDictionary(locale);
+
+/**
+ * Look up a UI string, filling `{name}` placeholders from `params`.
+ * Unknown keys are impossible: `UIKey` is derived from the English dictionary.
+ */
+export const t = (key: UIKey, params?: Record<string, string | number>): string => {
+  const value = strings[key];
+  if (!params) return value;
+  return value.replace(/\{(\w+)\}/g, (match, name: string) =>
+    name in params ? String(params[name]) : match,
+  );
+};
+
+/** Format a publish date in the active locale. `long` spells the month out;
+ *  `short` abbreviates it. Both are locale-aware, including field order. */
+export const formatDate = (date: Date, style: 'long' | 'short' = 'long'): string =>
+  new Intl.DateTimeFormat(locale, {
+    month: style,
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+
+/** Resolve a nav entry's label: a literal `label` wins, otherwise the
+ *  dictionary key. See `NAV_ITEMS` in `src/consts.ts`. */
+export const navLabel = (item: { label?: string; labelKey?: UIKey }): string =>
+  item.label ?? (item.labelKey ? t(item.labelKey) : '');

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -4,7 +4,7 @@
 //
 // To add a locale: copy `ja.ts`, translate the values, and register it in
 // `DICTIONARIES` below. Nothing else needs editing.
-import { SITE } from '../consts';
+import { SITE, type NavItem } from '../consts';
 import { en, type UIKey, type UIStrings } from './en';
 import { ja } from './ja';
 
@@ -49,7 +49,7 @@ export const formatDate = (date: Date, style: 'long' | 'short' = 'long'): string
     year: 'numeric',
   }).format(date);
 
-/** Resolve a nav entry's label: a literal `label` wins, otherwise the
- *  dictionary key. See `NAV_ITEMS` in `src/consts.ts`. */
-export const navLabel = (item: { label?: string; labelKey?: UIKey }): string =>
-  item.label ?? (item.labelKey ? t(item.labelKey) : '');
+/** Resolve a nav entry's label. `NavItem` requires exactly one of `label` or
+ *  `labelKey`, so there is no unlabelled case to fall back from. */
+export const navLabel = (item: NavItem): string =>
+  item.label !== undefined ? item.label : t(item.labelKey);

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -1,6 +1,8 @@
 // Japanese UI dictionary — shipped as a reference translation alongside `en`.
 // Copy this file to add your own locale; `UIStrings` makes a missing key a
 // type error, so nothing can silently fall back to English.
+//
+// Scope is UI chrome only — see the note at the top of `en.ts`.
 import type { UIStrings } from './en';
 
 export const ja: UIStrings = {
@@ -23,31 +25,16 @@ export const ja: UIStrings = {
   'pagination.status': '{total} ページ中 {current} ページ目',
 
   // Home
-  'home.description': '丁寧な技術的仕事のための、ミニマルなポートフォリオ兼ブログテーマ。',
-  'home.eyebrow': 'ポートフォリオ / 執筆 / システムノート',
-  'home.heading': '丁寧なデジタルワークのための、構造的ミニマリズム。',
-  'home.lead':
-    'Astro Keel は、プロジェクト・エッセイ・実務ノートに規律ある枠組みを与えます。エディトリアルな書体、整えられたリズム、細い罫線を貫く一色のアクセント。',
   'home.primaryLinks': '主要リンク',
   'home.viewWorks': '制作物を見る',
   'home.readNotes': 'ノートを読む',
   'home.overviewLabel': 'テーマの概要',
-  'home.principlesEyebrow': '設計方針',
-  'home.principlesHeading': '読みやすさが先、装飾は最後。',
-  'home.principleRhythmTitle': 'ベースラインのリズム',
-  'home.principleRhythmBody': '縦の余白は一定の拍を刻み、長い文章でも読み進めやすくします。',
-  'home.principleContentTitle': '型付きコンテンツ',
-  'home.principleContentBody': 'コレクションは、ケーススタディにも長く残るノートにも対応します。',
-  'home.principleLinesTitle': 'キールライン',
-  'home.principleLinesBody': '細い罫線だけで構造をつくり、装飾的な効果に頼りません。',
   'home.latestWorksEyebrow': '最新の制作物',
-  'home.latestWorksHeading': 'つくった記録。',
   'home.allWorks': 'すべての制作物',
+  'home.workTech': '{title} の使用技術',
   'home.worksEmpty':
     '<code>src/content/works</code> に制作物を追加すると、ここに最新のプロジェクトが並びます。',
-  'home.workTech': '{title} の使用技術',
   'home.latestBlogEyebrow': '最新のブログ',
-  'home.latestBlogHeading': 'フィールドノート。',
   'home.allPosts': 'すべての記事',
   'home.postsEmpty':
     '<code>src/content/blog</code> に記事を追加すると、ここに最新のノートが並びます。',
@@ -55,11 +42,7 @@ export const ja: UIStrings = {
   // Blog index
   'blog.title': 'ブログ',
   'blog.titlePaged': 'ブログ · {page} ページ目',
-  'blog.description': 'ノートと執筆 — Astro 向けのミニマルなポートフォリオ兼ブログテーマ、{site}。',
   'blog.eyebrow': 'ブログ',
-  'blog.heading': 'ノート、エッセイ、リリースログ。',
-  'blog.lead':
-    'ブログコレクションは、タグ・説明文・下書きの除外・公開日・任意のヒーロー画像に対応しています。',
   'blog.listLabel': 'ブログ記事',
   'blog.tagsEyebrow': 'タグ',
   'blog.tagsNavLabel': 'ブログのタグ',
@@ -77,6 +60,7 @@ export const ja: UIStrings = {
 
   // Blog post
   'post.eyebrow': 'ブログ',
+  'post.readingTime': '約{minutes}分で読めます',
   'post.tocLabel': '目次',
   'post.contentsEyebrow': '目次',
   'post.adjacentLabel': '前後の記事',
@@ -86,16 +70,17 @@ export const ja: UIStrings = {
   'post.breadcrumbHome': 'ホーム',
   'post.breadcrumbBlog': 'ブログ',
 
-  // Works index
-  'works.title': '制作物',
-  'works.description': '厳選したプロジェクトとケーススタディ — {site}。',
-  'works.eyebrow': '制作物',
-  'works.heading': '厳選したプロジェクトとケーススタディ。',
-  'works.lead':
-    'works コレクションは、説明文・使用技術・外部リンク・リポジトリ・サムネイル・並び順・公開日を型付きで扱います。',
-  'works.listLabel': '厳選した制作物',
+  // Comments (rendered only when GISCUS.enabled)
+  'comments.eyebrow': 'コメント',
+  'comments.failed':
+    'コメントを読み込めませんでした。スレッドは <a href="{url}" target="_blank" rel="noopener noreferrer">GitHub Discussions ↗</a> にあります。',
+  'comments.noscript':
+    'コメントの表示には JavaScript が必要です。スレッドは GitHub Discussions にあります。',
 
-  // Work detail
+  // Works
+  'works.title': '制作物',
+  'works.eyebrow': '制作物',
+  'works.listLabel': '厳選した制作物',
   'work.eyebrow': '制作物',
   'work.visit': 'プロジェクトを見る',
   'work.repository': 'リポジトリを見る',
@@ -103,38 +88,12 @@ export const ja: UIStrings = {
 
   // About
   'about.title': 'プロフィール',
-  'about.description': 'この {site} サイトを運営している人について。',
   'about.eyebrow': 'プロフィール',
-  'about.heading': '仕事の背後にいる人を、落ち着いた筆致で。',
-  'about.lead':
-    'このページは、簡潔な経歴、仕事の哲学、そして考え方が伝わるいくつかの要素を置くための場所です。',
-  'about.profileEyebrow': 'プロフィール',
-  'about.profileHeading': '静かなシステム、明快な文章、長持ちするインターフェース。',
-  'about.profileBody1':
-    'プロダクト戦略、インターフェースの設計、技術文書の執筆にまたがって仕事をしています。共通しているのは構造です。複雑な内容を、目で追いやすく、信頼でき、手入れしやすい形にすること。',
-  'about.profileBody2':
-    'Astro Keel は、声高な個人ブランドを押し出さずに、こうした文脈を書き添える余白を残しています。このプレースホルダーを、具体的な経歴、現在の役割、仕事を形づくっている制約に置き換えてください。',
   'about.ledgerLabel': '経歴の概要',
-  'about.focusTitle': 'いま取り組んでいること',
-  'about.focusBody':
-    '無駄のないコンテンツ基盤、ポートフォリオ、エディトリアルなプロダクトページの設計。',
-  'about.backgroundTitle': 'これまでの経験',
-  'about.backgroundBody':
-    'フロントエンド実装、デザインシステム、技術者向けの執筆にわたる経験。',
-  'about.contactTitle': '連絡先',
-  'about.contactBody': '稼働状況、協業の希望、直接の連絡手段などをこの欄に。',
-  'about.methodEyebrow': '進め方',
-  'about.methodHeading': '見た目より先に、構造を。',
-  'about.methodBody':
-    'このテーマはページを作業文書のように扱います。まず階層、次にリズム、最後に視覚的な個性。細い罫線、ゆとりのある余白、書体のコントラストが、内容と競わずに佇まいを担います。',
 
   // Search
   'search.title': '検索',
-  'search.description': '記事と制作物を検索 — {site}。',
   'search.eyebrow': '検索',
-  'search.heading': '記事と制作物を探す。',
-  'search.lead':
-    'Pagefind による完全静的な検索です。索引はビルド時に生成され、バックエンドは要りません。',
   'search.sectionLabel': 'サイト内検索',
   'search.fallback':
     '検索インデックスはビルド時に生成されます。<code>npm run build</code> を実行し、プレビューでお試しください。開発サーバーでは利用できません。',
@@ -150,8 +109,4 @@ export const ja: UIStrings = {
   'notFound.home': 'ホームへ戻る',
   'notFound.blog': 'ブログを読む',
   'notFound.works': '制作物を見る',
-
-  // Generated Open Graph images
-  'og.blog': 'ブログ',
-  'og.work': '制作物',
 };

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -1,0 +1,157 @@
+// Japanese UI dictionary — shipped as a reference translation alongside `en`.
+// Copy this file to add your own locale; `UIStrings` makes a missing key a
+// type error, so nothing can silently fall back to English.
+import type { UIStrings } from './en';
+
+export const ja: UIStrings = {
+  // Header, footer, and other chrome
+  'nav.home': 'ホーム',
+  'nav.about': 'プロフィール',
+  'nav.works': '制作物',
+  'nav.blog': 'ブログ',
+  'nav.search': '検索',
+  'nav.label': 'メインナビゲーション',
+  'nav.brandHome': '{site} のホーム',
+  'theme.toggle': '配色テーマを切り替える',
+  'footer.notes': 'ノート',
+  'social.label': 'ソーシャルリンク',
+
+  // Pagination
+  'pagination.label': 'ページ送り',
+  'pagination.newer': '← 新しい記事',
+  'pagination.older': '古い記事 →',
+  'pagination.status': '{total} ページ中 {current} ページ目',
+
+  // Home
+  'home.description': '丁寧な技術的仕事のための、ミニマルなポートフォリオ兼ブログテーマ。',
+  'home.eyebrow': 'ポートフォリオ / 執筆 / システムノート',
+  'home.heading': '丁寧なデジタルワークのための、構造的ミニマリズム。',
+  'home.lead':
+    'Astro Keel は、プロジェクト・エッセイ・実務ノートに規律ある枠組みを与えます。エディトリアルな書体、整えられたリズム、細い罫線を貫く一色のアクセント。',
+  'home.primaryLinks': '主要リンク',
+  'home.viewWorks': '制作物を見る',
+  'home.readNotes': 'ノートを読む',
+  'home.overviewLabel': 'テーマの概要',
+  'home.principlesEyebrow': '設計方針',
+  'home.principlesHeading': '読みやすさが先、装飾は最後。',
+  'home.principleRhythmTitle': 'ベースラインのリズム',
+  'home.principleRhythmBody': '縦の余白は一定の拍を刻み、長い文章でも読み進めやすくします。',
+  'home.principleContentTitle': '型付きコンテンツ',
+  'home.principleContentBody': 'コレクションは、ケーススタディにも長く残るノートにも対応します。',
+  'home.principleLinesTitle': 'キールライン',
+  'home.principleLinesBody': '細い罫線だけで構造をつくり、装飾的な効果に頼りません。',
+  'home.latestWorksEyebrow': '最新の制作物',
+  'home.latestWorksHeading': 'つくった記録。',
+  'home.allWorks': 'すべての制作物',
+  'home.worksEmpty':
+    '<code>src/content/works</code> に制作物を追加すると、ここに最新のプロジェクトが並びます。',
+  'home.workTech': '{title} の使用技術',
+  'home.latestBlogEyebrow': '最新のブログ',
+  'home.latestBlogHeading': 'フィールドノート。',
+  'home.allPosts': 'すべての記事',
+  'home.postsEmpty':
+    '<code>src/content/blog</code> に記事を追加すると、ここに最新のノートが並びます。',
+
+  // Blog index
+  'blog.title': 'ブログ',
+  'blog.titlePaged': 'ブログ · {page} ページ目',
+  'blog.description': 'ノートと執筆 — Astro 向けのミニマルなポートフォリオ兼ブログテーマ、{site}。',
+  'blog.eyebrow': 'ブログ',
+  'blog.heading': 'ノート、エッセイ、リリースログ。',
+  'blog.lead':
+    'ブログコレクションは、タグ・説明文・下書きの除外・公開日・任意のヒーロー画像に対応しています。',
+  'blog.listLabel': 'ブログ記事',
+  'blog.tagsEyebrow': 'タグ',
+  'blog.tagsNavLabel': 'ブログのタグ',
+
+  // Tag archive
+  'tag.title': '「{tag}」タグの記事',
+  'tag.titlePaged': '「{tag}」タグの記事 · {page} ページ目',
+  'tag.description': '{site} の「{tag}」タグが付いたブログ記事。',
+  'tag.eyebrow': 'タグ',
+  'tag.lead': '「{tag}」タグにまとめたノート。',
+  'tag.listLabel': '「{tag}」タグの記事',
+  'tag.moreTagsEyebrow': 'ほかのタグ',
+  'tag.otherTagsNavLabel': 'ほかのブログタグ',
+  'tag.allPosts': 'すべての記事',
+
+  // Blog post
+  'post.eyebrow': 'ブログ',
+  'post.tocLabel': '目次',
+  'post.contentsEyebrow': '目次',
+  'post.adjacentLabel': '前後の記事',
+  'post.previous': '前の記事',
+  'post.next': '次の記事',
+  'post.relatedEyebrow': '関連記事',
+  'post.breadcrumbHome': 'ホーム',
+  'post.breadcrumbBlog': 'ブログ',
+
+  // Works index
+  'works.title': '制作物',
+  'works.description': '厳選したプロジェクトとケーススタディ — {site}。',
+  'works.eyebrow': '制作物',
+  'works.heading': '厳選したプロジェクトとケーススタディ。',
+  'works.lead':
+    'works コレクションは、説明文・使用技術・外部リンク・リポジトリ・サムネイル・並び順・公開日を型付きで扱います。',
+  'works.listLabel': '厳選した制作物',
+
+  // Work detail
+  'work.eyebrow': '制作物',
+  'work.visit': 'プロジェクトを見る',
+  'work.repository': 'リポジトリを見る',
+  'work.stackEyebrow': '技術構成',
+
+  // About
+  'about.title': 'プロフィール',
+  'about.description': 'この {site} サイトを運営している人について。',
+  'about.eyebrow': 'プロフィール',
+  'about.heading': '仕事の背後にいる人を、落ち着いた筆致で。',
+  'about.lead':
+    'このページは、簡潔な経歴、仕事の哲学、そして考え方が伝わるいくつかの要素を置くための場所です。',
+  'about.profileEyebrow': 'プロフィール',
+  'about.profileHeading': '静かなシステム、明快な文章、長持ちするインターフェース。',
+  'about.profileBody1':
+    'プロダクト戦略、インターフェースの設計、技術文書の執筆にまたがって仕事をしています。共通しているのは構造です。複雑な内容を、目で追いやすく、信頼でき、手入れしやすい形にすること。',
+  'about.profileBody2':
+    'Astro Keel は、声高な個人ブランドを押し出さずに、こうした文脈を書き添える余白を残しています。このプレースホルダーを、具体的な経歴、現在の役割、仕事を形づくっている制約に置き換えてください。',
+  'about.ledgerLabel': '経歴の概要',
+  'about.focusTitle': 'いま取り組んでいること',
+  'about.focusBody':
+    '無駄のないコンテンツ基盤、ポートフォリオ、エディトリアルなプロダクトページの設計。',
+  'about.backgroundTitle': 'これまでの経験',
+  'about.backgroundBody':
+    'フロントエンド実装、デザインシステム、技術者向けの執筆にわたる経験。',
+  'about.contactTitle': '連絡先',
+  'about.contactBody': '稼働状況、協業の希望、直接の連絡手段などをこの欄に。',
+  'about.methodEyebrow': '進め方',
+  'about.methodHeading': '見た目より先に、構造を。',
+  'about.methodBody':
+    'このテーマはページを作業文書のように扱います。まず階層、次にリズム、最後に視覚的な個性。細い罫線、ゆとりのある余白、書体のコントラストが、内容と競わずに佇まいを担います。',
+
+  // Search
+  'search.title': '検索',
+  'search.description': '記事と制作物を検索 — {site}。',
+  'search.eyebrow': '検索',
+  'search.heading': '記事と制作物を探す。',
+  'search.lead':
+    'Pagefind による完全静的な検索です。索引はビルド時に生成され、バックエンドは要りません。',
+  'search.sectionLabel': 'サイト内検索',
+  'search.fallback':
+    '検索インデックスはビルド時に生成されます。<code>npm run build</code> を実行し、プレビューでお試しください。開発サーバーでは利用できません。',
+
+  // 404
+  'notFound.title': 'ページが見つかりません',
+  'notFound.description': 'お探しのページは存在しません。',
+  'notFound.eyebrow': '404 — 見つかりません',
+  'notFound.heading': 'このページは航路から外れました。',
+  'notFound.lead':
+    'アドレスが変わったか、はじめから存在しなかったのかもしれません。下のキールラインが、穏やかな水域へ戻る道です。',
+  'notFound.linksLabel': '復帰用リンク',
+  'notFound.home': 'ホームへ戻る',
+  'notFound.blog': 'ブログを読む',
+  'notFound.works': '制作物を見る',
+
+  // Generated Open Graph images
+  'og.blog': 'ブログ',
+  'og.work': '制作物',
+};

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -72,8 +72,8 @@ export const ja: UIStrings = {
 
   // Comments (rendered only when GISCUS.enabled)
   'comments.eyebrow': 'コメント',
-  'comments.failed':
-    'コメントを読み込めませんでした。スレッドは <a href="{url}" target="_blank" rel="noopener noreferrer">GitHub Discussions ↗</a> にあります。',
+  'comments.failed': 'コメントを読み込めませんでした。スレッドは {link} にあります。',
+  'comments.failedLink': 'GitHub Discussions ↗',
   'comments.noscript':
     'コメントの表示には JavaScript が必要です。スレッドは GitHub Discussions にあります。',
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,6 +9,7 @@ import '../styles/global.css';
 import { ClientRouter } from 'astro:transitions';
 import { withBase } from '../lib/url';
 import { SITE, NAV_ITEMS } from '../consts';
+import { locale, navLabel, t } from '../i18n';
 import CodeCopy from '../components/CodeCopy.astro';
 import SocialLinks from '../components/SocialLinks.astro';
 
@@ -43,7 +44,7 @@ const isActive = (href: string) => {
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={locale}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
@@ -88,20 +89,20 @@ const isActive = (href: string) => {
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href={withBase('/')} aria-label={`${siteName} home`}>
+      <a class="brand" href={withBase('/')} aria-label={t('nav.brandHome', { site: siteName })}>
         <span class="brand-mark" aria-hidden="true"></span>
         <span>{siteName}</span>
       </a>
-      <nav class="site-nav" aria-label="Main navigation">
+      <nav class="site-nav" aria-label={t('nav.label')}>
         {
           NAV_ITEMS.map((item) => (
             <a href={withBase(item.href)} aria-current={isActive(item.href) ? 'page' : undefined}>
-              {item.label}
+              {navLabel(item)}
             </a>
           ))
         }
       </nav>
-      <button class="theme-toggle" type="button" aria-label="Toggle color theme" data-theme-toggle>
+      <button class="theme-toggle" type="button" aria-label={t('theme.toggle')} data-theme-toggle>
         <span aria-hidden="true"></span>
       </button>
     </header>
@@ -113,7 +114,7 @@ const isActive = (href: string) => {
     <footer class="site-footer">
       <p>{SITE.footerText}</p>
       <div class="footer-links">
-        <a href={withBase('/blog/')}>Notes</a>
+        <a href={withBase('/blog/')}>{t('footer.notes')}</a>
         <a href="https://almanac.p4ni.com" target="_blank" rel="noopener noreferrer">Almanac ↗</a>
       </div>
       <SocialLinks />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -57,17 +57,18 @@ const isActive = (href: string) => {
     <link rel="alternate" type="application/rss+xml" title={siteName} href={withBase('/rss.xml')} />
     <title>{fullTitle}</title>
 
-    <!-- Open Graph -->
+    {/* Astro comment syntax — an HTML comment here would ship on every page. */}
+    {/* Open Graph */}
     <meta property="og:type" content={ogType} />
     <meta property="og:site_name" content={siteName} />
     <meta property="og:title" content={fullTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonicalURL} />
-    <!-- Open Graph wants `ja_JP`, not the `ja-JP` of `<html lang>`. -->
+    {/* Open Graph wants `ja_JP`, not the `ja-JP` of `<html lang>`. */}
     <meta property="og:locale" content={locale.replace('-', '_')} />
     {imageURL && <meta property="og:image" content={imageURL} />}
 
-    <!-- Twitter -->
+    {/* Twitter */}
     <meta name="twitter:card" content={imageURL ? 'summary_large_image' : 'summary'} />
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={description} />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -63,6 +63,8 @@ const isActive = (href: string) => {
     <meta property="og:title" content={fullTitle} />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonicalURL} />
+    <!-- Open Graph wants `ja_JP`, not the `ja-JP` of `<html lang>`. -->
+    <meta property="og:locale" content={locale.replace('-', '_')} />
     {imageURL && <meta property="og:image" content={imageURL} />}
 
     <!-- Twitter -->

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,20 +1,18 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { withBase } from '../lib/url';
+import { t } from '../i18n';
 ---
 
-<BaseLayout title="Page not found" description="The page you were looking for does not exist.">
+<BaseLayout title={t('notFound.title')} description={t('notFound.description')}>
   <section class="hero section">
-    <p class="eyebrow">404 — Not found</p>
-    <h1>This page drifted off course.</h1>
-    <p class="lead">
-      The address may have moved, or it never existed. The keel lines below lead back to
-      steady water.
-    </p>
-    <div class="action-row" aria-label="Recovery links">
-      <a class="button" href={withBase('/')}>Back home</a>
-      <a class="text-link" href={withBase('/blog/')}>Read the blog</a>
-      <a class="text-link" href={withBase('/works/')}>Browse works</a>
+    <p class="eyebrow">{t('notFound.eyebrow')}</p>
+    <h1>{t('notFound.heading')}</h1>
+    <p class="lead">{t('notFound.lead')}</p>
+    <div class="action-row" aria-label={t('notFound.linksLabel')}>
+      <a class="button" href={withBase('/')}>{t('notFound.home')}</a>
+      <a class="text-link" href={withBase('/blog/')}>{t('notFound.blog')}</a>
+      <a class="text-link" href={withBase('/works/')}>{t('notFound.works')}</a>
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,67 +1,54 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { SITE } from '../../consts';
+import { t } from '../../i18n';
 ---
 
-<BaseLayout title="About" description="About the author behind this Astro Keel site.">
+<BaseLayout title={t('about.title')} description={t('about.description', { site: SITE.title })}>
   <section class="page-head section">
-    <p class="eyebrow">About</p>
-    <h1>A measured profile for the person behind the work.</h1>
-    <p class="lead">
-      This page is shaped for a concise biography, a working philosophy, and the handful
-      of details that help readers understand how you think.
-    </p>
+    <p class="eyebrow">{t('about.eyebrow')}</p>
+    <h1>{t('about.heading')}</h1>
+    <p class="lead">{t('about.lead')}</p>
   </section>
 
   <section class="section prose-grid">
     <div>
-      <p class="eyebrow">Profile</p>
-      <h2>Quiet systems, clear writing, durable interfaces.</h2>
+      <p class="eyebrow">{t('about.profileEyebrow')}</p>
+      <h2>{t('about.profileHeading')}</h2>
     </div>
     <div class="prose-stack">
-      <p>
-        I work across product strategy, interface systems, and technical writing. The
-        common thread is structure: making complex material easier to scan, trust, and
-        maintain.
-      </p>
-      <p>
-        Astro Keel leaves room for this kind of context without forcing a loud personal
-        brand. Replace this placeholder with a specific background, current role, and
-        the constraints that shape your work.
-      </p>
+      <p>{t('about.profileBody1')}</p>
+      <p>{t('about.profileBody2')}</p>
     </div>
   </section>
 
-  <section class="section" aria-label="Experience summary">
+  <section class="section" aria-label={t('about.ledgerLabel')}>
     <div class="about-ledger">
       <article>
         <span>01</span>
-        <h3>Current focus</h3>
-        <p>Designing lean content systems, portfolio surfaces, and editorial product pages.</p>
+        <h3>{t('about.focusTitle')}</h3>
+        <p>{t('about.focusBody')}</p>
       </article>
       <article>
         <span>02</span>
-        <h3>Background</h3>
-        <p>Experience spanning frontend implementation, design systems, and writing for technical audiences.</p>
+        <h3>{t('about.backgroundTitle')}</h3>
+        <p>{t('about.backgroundBody')}</p>
       </article>
       <article>
         <span>03</span>
-        <h3>Contact</h3>
-        <p>Use this section for availability, collaboration preferences, or a direct contact route.</p>
+        <h3>{t('about.contactTitle')}</h3>
+        <p>{t('about.contactBody')}</p>
       </article>
     </div>
   </section>
 
   <section class="section prose-grid about-closing">
     <div>
-      <p class="eyebrow">Method</p>
-      <h2>Structure before surface.</h2>
+      <p class="eyebrow">{t('about.methodEyebrow')}</p>
+      <h2>{t('about.methodHeading')}</h2>
     </div>
     <div class="prose-stack">
-      <p>
-        The theme treats the page like a working document: hierarchy first, rhythm second,
-        visual signature third. Fine rules, generous spacing, and type contrast carry the
-        identity without competing with the content.
-      </p>
+      <p>{t('about.methodBody')}</p>
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,24 +1,39 @@
 ---
+// The prose on this page is placeholder copy — rewrite it as your own. It is
+// intentionally *not* in `src/i18n/`: the dictionary holds UI chrome, so a
+// translator isn't handed someone else's biography, and you don't have to open
+// a dictionary file to edit your own about page.
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { SITE } from '../../consts';
 import { t } from '../../i18n';
 ---
 
-<BaseLayout title={t('about.title')} description={t('about.description', { site: SITE.title })}>
+<BaseLayout title={t('about.title')} description={`About the author behind this ${SITE.title} site.`}>
   <section class="page-head section">
     <p class="eyebrow">{t('about.eyebrow')}</p>
-    <h1>{t('about.heading')}</h1>
-    <p class="lead">{t('about.lead')}</p>
+    <h1>A measured profile for the person behind the work.</h1>
+    <p class="lead">
+      This page is shaped for a concise biography, a working philosophy, and the handful
+      of details that help readers understand how you think.
+    </p>
   </section>
 
   <section class="section prose-grid">
     <div>
-      <p class="eyebrow">{t('about.profileEyebrow')}</p>
-      <h2>{t('about.profileHeading')}</h2>
+      <p class="eyebrow">Profile</p>
+      <h2>Quiet systems, clear writing, durable interfaces.</h2>
     </div>
     <div class="prose-stack">
-      <p>{t('about.profileBody1')}</p>
-      <p>{t('about.profileBody2')}</p>
+      <p>
+        I work across product strategy, interface systems, and technical writing. The
+        common thread is structure: making complex material easier to scan, trust, and
+        maintain.
+      </p>
+      <p>
+        Astro Keel leaves room for this kind of context without forcing a loud personal
+        brand. Replace this placeholder with a specific background, current role, and
+        the constraints that shape your work.
+      </p>
     </div>
   </section>
 
@@ -26,29 +41,33 @@ import { t } from '../../i18n';
     <div class="about-ledger">
       <article>
         <span>01</span>
-        <h3>{t('about.focusTitle')}</h3>
-        <p>{t('about.focusBody')}</p>
+        <h3>Current focus</h3>
+        <p>Designing lean content systems, portfolio surfaces, and editorial product pages.</p>
       </article>
       <article>
         <span>02</span>
-        <h3>{t('about.backgroundTitle')}</h3>
-        <p>{t('about.backgroundBody')}</p>
+        <h3>Background</h3>
+        <p>Experience spanning frontend implementation, design systems, and writing for technical audiences.</p>
       </article>
       <article>
         <span>03</span>
-        <h3>{t('about.contactTitle')}</h3>
-        <p>{t('about.contactBody')}</p>
+        <h3>Contact</h3>
+        <p>Use this section for availability, collaboration preferences, or a direct contact route.</p>
       </article>
     </div>
   </section>
 
   <section class="section prose-grid about-closing">
     <div>
-      <p class="eyebrow">{t('about.methodEyebrow')}</p>
-      <h2>{t('about.methodHeading')}</h2>
+      <p class="eyebrow">Method</p>
+      <h2>Structure before surface.</h2>
     </div>
     <div class="prose-stack">
-      <p>{t('about.methodBody')}</p>
+      <p>
+        The theme treats the page like a working document: hierarchy first, rhythm second,
+        visual signature third. Fine rules, generous spacing, and type contrast carry the
+        identity without competing with the content.
+      </p>
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -5,7 +5,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Pagination from '../../components/Pagination.astro';
 import { withBase } from '../../lib/url';
 import { SITE } from '../../consts';
-import { formatDate, t } from '../../i18n';
+import { formatDate, readingTime, t } from '../../i18n';
 
 export const getStaticPaths = (async ({ paginate }) => {
   const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
@@ -26,7 +26,7 @@ const readingTimes = new Map(
   await Promise.all(
     posts.map(async (post) => {
       const { remarkPluginFrontmatter } = await render(post);
-      return [post.id, remarkPluginFrontmatter.minutesRead as number] as const;
+      return [post.id, readingTime(remarkPluginFrontmatter.minutesRead)] as const;
     }),
   ),
 );
@@ -60,7 +60,7 @@ const pageTitle =
             <article class="entry-card">
               <div class="entry-meta">
                 <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate, 'short')}</time>
-                <span>{t('post.readingTime', { minutes: readingTimes.get(post.id) ?? 1 })}</span>
+                <span>{readingTimes.get(post.id)}</span>
                 <span>{post.data.tags.join(' / ')}</span>
               </div>
               <h2><a href={withBase(`/blog/${post.id}/`)}>{post.data.title}</a></h2>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -26,7 +26,7 @@ const readingTimes = new Map(
   await Promise.all(
     posts.map(async (post) => {
       const { remarkPluginFrontmatter } = await render(post);
-      return [post.id, remarkPluginFrontmatter.minutesRead as string] as const;
+      return [post.id, remarkPluginFrontmatter.minutesRead as number] as const;
     }),
   ),
 );
@@ -35,11 +35,14 @@ const pageTitle =
   page.currentPage === 1 ? t('blog.title') : t('blog.titlePaged', { page: page.currentPage });
 ---
 
-<BaseLayout title={pageTitle} description={t('blog.description', { site: SITE.title })}>
+<BaseLayout title={pageTitle} description={`Notes and writing — ${SITE.title}, a minimal portfolio and blog theme for Astro.`}>
   <section class="page-head section">
     <p class="eyebrow">{t('blog.eyebrow')}</p>
-    <h1>{t('blog.heading')}</h1>
-    <p class="lead">{t('blog.lead')}</p>
+    <h1>Notes, essays, and release logs.</h1>
+    <p class="lead">
+      The blog collection supports tags, descriptions, draft filtering, publish dates,
+      and optional hero images.
+    </p>
   </section>
 
   <section class="section content-index" aria-label={t('blog.listLabel')}>
@@ -57,7 +60,7 @@ const pageTitle =
             <article class="entry-card">
               <div class="entry-meta">
                 <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate, 'short')}</time>
-                <span>{readingTimes.get(post.id)}</span>
+                <span>{t('post.readingTime', { minutes: readingTimes.get(post.id) ?? 1 })}</span>
                 <span>{post.data.tags.join(' / ')}</span>
               </div>
               <h2><a href={withBase(`/blog/${post.id}/`)}>{post.data.title}</a></h2>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -4,6 +4,8 @@ import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Pagination from '../../components/Pagination.astro';
 import { withBase } from '../../lib/url';
+import { SITE } from '../../consts';
+import { formatDate, t } from '../../i18n';
 
 export const getStaticPaths = (async ({ paginate }) => {
   const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
@@ -29,30 +31,21 @@ const readingTimes = new Map(
   ),
 );
 
-const formatDate = (date: Date) =>
-  new Intl.DateTimeFormat('en', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(date);
-
-const pageTitle = page.currentPage === 1 ? 'Blog' : `Blog · Page ${page.currentPage}`;
+const pageTitle =
+  page.currentPage === 1 ? t('blog.title') : t('blog.titlePaged', { page: page.currentPage });
 ---
 
-<BaseLayout title={pageTitle} description="Notes and writing — Astro Keel, a minimal portfolio and blog theme for Astro.">
+<BaseLayout title={pageTitle} description={t('blog.description', { site: SITE.title })}>
   <section class="page-head section">
-    <p class="eyebrow">Blog</p>
-    <h1>Notes, essays, and release logs.</h1>
-    <p class="lead">
-      The blog collection supports tags, descriptions, draft filtering, publish dates,
-      and optional hero images.
-    </p>
+    <p class="eyebrow">{t('blog.eyebrow')}</p>
+    <h1>{t('blog.heading')}</h1>
+    <p class="lead">{t('blog.lead')}</p>
   </section>
 
-  <section class="section content-index" aria-label="Blog posts">
+  <section class="section content-index" aria-label={t('blog.listLabel')}>
     <div class="index-sidebar">
-      <p class="eyebrow">Tags</p>
-      <nav class="tag-cloud" aria-label="Blog tags">
+      <p class="eyebrow">{t('blog.tagsEyebrow')}</p>
+      <nav class="tag-cloud" aria-label={t('blog.tagsNavLabel')}>
         {allTags.map((tag) => <a href={withBase(`/blog/tags/${tag}/`)}>{tag}</a>)}
       </nav>
     </div>
@@ -63,7 +56,7 @@ const pageTitle = page.currentPage === 1 ? 'Blog' : `Blog · Page ${page.current
           posts.map((post) => (
             <article class="entry-card">
               <div class="entry-meta">
-                <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate)}</time>
+                <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate, 'short')}</time>
                 <span>{readingTimes.get(post.id)}</span>
                 <span>{post.data.tags.join(' / ')}</span>
               </div>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -6,7 +6,7 @@ import StructuredData from '../../components/StructuredData.astro';
 import Comments from '../../components/Comments.astro';
 import { withBase } from '../../lib/url';
 import { SITE } from '../../consts';
-import { formatDate, t } from '../../i18n';
+import { formatDate, readingTime, t } from '../../i18n';
 
 export async function getStaticPaths() {
   // Newest-first, same ordering as the blog index.
@@ -85,7 +85,7 @@ const schema = [
       <p class="lead">{entry.data.description}</p>
       <div class="entry-meta">
         <time datetime={entry.data.publishDate.toISOString()}>{formatDate(entry.data.publishDate)}</time>
-        <span>{t('post.readingTime', { minutes: remarkPluginFrontmatter.minutesRead })}</span>
+        <span>{readingTime(remarkPluginFrontmatter.minutesRead)}</span>
         <span>{entry.data.tags.join(' / ')}</span>
       </div>
       {

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -85,7 +85,7 @@ const schema = [
       <p class="lead">{entry.data.description}</p>
       <div class="entry-meta">
         <time datetime={entry.data.publishDate.toISOString()}>{formatDate(entry.data.publishDate)}</time>
-        <span>{remarkPluginFrontmatter.minutesRead}</span>
+        <span>{t('post.readingTime', { minutes: remarkPluginFrontmatter.minutesRead })}</span>
         <span>{entry.data.tags.join(' / ')}</span>
       </div>
       {

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -6,6 +6,7 @@ import StructuredData from '../../components/StructuredData.astro';
 import Comments from '../../components/Comments.astro';
 import { withBase } from '../../lib/url';
 import { SITE } from '../../consts';
+import { formatDate, t } from '../../i18n';
 
 export async function getStaticPaths() {
   // Newest-first, same ordering as the blog index.
@@ -44,13 +45,6 @@ export async function getStaticPaths() {
 const { entry, newer, older, related } = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await render(entry);
 
-const formatDate = (date: Date) =>
-  new Intl.DateTimeFormat('en', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(date);
-
 // JSON-LD needs absolute URLs — resolve against `site` (astro.config.mjs).
 const site = Astro.site ?? new URL(Astro.url.origin);
 const absolute = (path: string) => new URL(withBase(path), site).href;
@@ -69,8 +63,8 @@ const schema = [
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
     itemListElement: [
-      { '@type': 'ListItem', position: 1, name: 'Home', item: absolute('/') },
-      { '@type': 'ListItem', position: 2, name: 'Blog', item: absolute('/blog/') },
+      { '@type': 'ListItem', position: 1, name: t('post.breadcrumbHome'), item: absolute('/') },
+      { '@type': 'ListItem', position: 2, name: t('post.breadcrumbBlog'), item: absolute('/blog/') },
       { '@type': 'ListItem', position: 3, name: entry.data.title },
     ],
   },
@@ -86,7 +80,7 @@ const schema = [
   <StructuredData slot="head" schema={schema} />
   <article data-pagefind-body>
     <header class="page-head section article-head">
-      <p class="eyebrow">Blog</p>
+      <p class="eyebrow">{t('post.eyebrow')}</p>
       <h1>{entry.data.title}</h1>
       <p class="lead">{entry.data.description}</p>
       <div class="entry-meta">
@@ -108,8 +102,8 @@ const schema = [
     </header>
 
     <div class="section article-layout">
-      <aside class="article-toc" aria-label="Table of contents">
-        <p class="eyebrow">Contents</p>
+      <aside class="article-toc" aria-label={t('post.tocLabel')}>
+        <p class="eyebrow">{t('post.contentsEyebrow')}</p>
         <nav>
           {
             headings
@@ -126,11 +120,11 @@ const schema = [
 
   {
     (older || newer) && (
-      <nav class="section post-nav-section" aria-label="Adjacent posts">
+      <nav class="section post-nav-section" aria-label={t('post.adjacentLabel')}>
         <div class="post-nav">
           {older ? (
             <a rel="prev" href={withBase(`/blog/${older.id}/`)}>
-              <span class="post-nav-label">Previous</span>
+              <span class="post-nav-label">{t('post.previous')}</span>
               <span class="post-nav-title">{older.data.title}</span>
             </a>
           ) : (
@@ -138,7 +132,7 @@ const schema = [
           )}
           {newer ? (
             <a rel="next" class="post-nav-next" href={withBase(`/blog/${newer.id}/`)}>
-              <span class="post-nav-label">Next</span>
+              <span class="post-nav-label">{t('post.next')}</span>
               <span class="post-nav-title">{newer.data.title}</span>
             </a>
           ) : (
@@ -153,7 +147,7 @@ const schema = [
     related.length > 0 && (
       <aside class="section post-nav-section" aria-labelledby="related-heading">
         <p class="eyebrow" id="related-heading">
-          Related
+          {t('post.relatedEyebrow')}
         </p>
         <ul class="related-list">
           {related.map((post) => (

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -29,7 +29,7 @@ const readingTimes = new Map(
   await Promise.all(
     taggedPosts.map(async (post) => {
       const { remarkPluginFrontmatter } = await render(post);
-      return [post.id, remarkPluginFrontmatter.minutesRead as string] as const;
+      return [post.id, remarkPluginFrontmatter.minutesRead as number] as const;
     }),
   ),
 );
@@ -63,7 +63,7 @@ const pageTitle =
             <article class="entry-card">
               <div class="entry-meta">
                 <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate, 'short')}</time>
-                <span>{readingTimes.get(post.id)}</span>
+                <span>{t('post.readingTime', { minutes: readingTimes.get(post.id) ?? 1 })}</span>
                 <span>{post.data.tags.join(' / ')}</span>
               </div>
               <h2><a href={withBase(`/blog/${post.id}/`)}>{post.data.title}</a></h2>

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -5,7 +5,7 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import Pagination from '../../../../components/Pagination.astro';
 import { withBase } from '../../../../lib/url';
 import { SITE } from '../../../../consts';
-import { formatDate, t } from '../../../../i18n';
+import { formatDate, readingTime, t } from '../../../../i18n';
 
 export const getStaticPaths = (async ({ paginate }) => {
   const posts = await getCollection('blog', ({ data }) => !data.draft);
@@ -29,7 +29,7 @@ const readingTimes = new Map(
   await Promise.all(
     taggedPosts.map(async (post) => {
       const { remarkPluginFrontmatter } = await render(post);
-      return [post.id, remarkPluginFrontmatter.minutesRead as number] as const;
+      return [post.id, readingTime(remarkPluginFrontmatter.minutesRead)] as const;
     }),
   ),
 );
@@ -63,7 +63,7 @@ const pageTitle =
             <article class="entry-card">
               <div class="entry-meta">
                 <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate, 'short')}</time>
-                <span>{t('post.readingTime', { minutes: readingTimes.get(post.id) ?? 1 })}</span>
+                <span>{readingTimes.get(post.id)}</span>
                 <span>{post.data.tags.join(' / ')}</span>
               </div>
               <h2><a href={withBase(`/blog/${post.id}/`)}>{post.data.title}</a></h2>

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -4,6 +4,8 @@ import type { GetStaticPaths, InferGetStaticPropsType } from 'astro';
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
 import Pagination from '../../../../components/Pagination.astro';
 import { withBase } from '../../../../lib/url';
+import { SITE } from '../../../../consts';
+import { formatDate, t } from '../../../../i18n';
 
 export const getStaticPaths = (async ({ paginate }) => {
   const posts = await getCollection('blog', ({ data }) => !data.draft);
@@ -32,31 +34,24 @@ const readingTimes = new Map(
   ),
 );
 
-const formatDate = (date: Date) =>
-  new Intl.DateTimeFormat('en', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(date);
-
 const pageTitle =
   page.currentPage === 1
-    ? `Posts tagged “${tag}”`
-    : `Posts tagged “${tag}” · Page ${page.currentPage}`;
+    ? t('tag.title', { tag })
+    : t('tag.titlePaged', { tag, page: page.currentPage });
 ---
 
-<BaseLayout title={pageTitle} description={`Blog posts tagged ${tag} on Astro Keel.`}>
+<BaseLayout title={pageTitle} description={t('tag.description', { tag, site: SITE.title })}>
   <section class="page-head section">
-    <p class="eyebrow">Tag</p>
+    <p class="eyebrow">{t('tag.eyebrow')}</p>
     <h1>{tag}</h1>
-    <p class="lead">Notes collected under the {tag} tag.</p>
+    <p class="lead">{t('tag.lead', { tag })}</p>
   </section>
 
-  <section class="section content-index" aria-label={`${tag} posts`}>
+  <section class="section content-index" aria-label={t('tag.listLabel', { tag })}>
     <div class="index-sidebar">
-      <p class="eyebrow">More tags</p>
-      <nav class="tag-cloud" aria-label="Other blog tags">
-        <a href={withBase('/blog/')}>All posts</a>
+      <p class="eyebrow">{t('tag.moreTagsEyebrow')}</p>
+      <nav class="tag-cloud" aria-label={t('tag.otherTagsNavLabel')}>
+        <a href={withBase('/blog/')}>{t('tag.allPosts')}</a>
         {otherTags.map((item) => <a href={withBase(`/blog/tags/${item}/`)}>{item}</a>)}
       </nav>
     </div>
@@ -67,7 +62,7 @@ const pageTitle =
           taggedPosts.map((post) => (
             <article class="entry-card">
               <div class="entry-meta">
-                <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate)}</time>
+                <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate, 'short')}</time>
                 <span>{readingTimes.get(post.id)}</span>
                 <span>{post.data.tags.join(' / ')}</span>
               </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,12 +29,16 @@ const websiteSchema = {
 };
 ---
 
-<BaseLayout description={t('home.description')}>
+<BaseLayout description={SITE.description}>
   <StructuredData slot="head" schema={websiteSchema} />
   <section class="hero section">
-    <p class="eyebrow">{t('home.eyebrow')}</p>
-    <h1>{t('home.heading')}</h1>
-    <p class="lead">{t('home.lead')}</p>
+    <p class="eyebrow">Portfolio / writing / systems notes</p>
+    <h1>Structural minimalism for careful digital work.</h1>
+    <p class="lead">
+      Astro Keel gives projects, essays, and professional notes a disciplined frame:
+      editorial type, measured rhythm, and a single accent carried through fine structural
+      rules.
+    </p>
     <div class="action-row" aria-label={t('home.primaryLinks')}>
       <a class="button" href={withBase('/works/')}>{t('home.viewWorks')}</a>
       <a class="text-link" href={withBase('/blog/')}>{t('home.readNotes')}</a>
@@ -43,21 +47,21 @@ const websiteSchema = {
 
   <section class="section split-overview" aria-label={t('home.overviewLabel')}>
     <div>
-      <p class="eyebrow">{t('home.principlesEyebrow')}</p>
-      <h2>{t('home.principlesHeading')}</h2>
+      <p class="eyebrow">Principles</p>
+      <h2>Readable first, decorative last.</h2>
     </div>
     <div class="feature-list">
       <article>
-        <h3>{t('home.principleRhythmTitle')}</h3>
-        <p>{t('home.principleRhythmBody')}</p>
+        <h3>Baseline rhythm</h3>
+        <p>Vertical spacing follows a steady cadence for long-form reading.</p>
       </article>
       <article>
-        <h3>{t('home.principleContentTitle')}</h3>
-        <p>{t('home.principleContentBody')}</p>
+        <h3>Typed content</h3>
+        <p>Collections are prepared for project case studies and durable notes.</p>
       </article>
       <article>
-        <h3>{t('home.principleLinesTitle')}</h3>
-        <p>{t('home.principleLinesBody')}</p>
+        <h3>Keel lines</h3>
+        <p>Fine rules create structure without relying on decorative effects.</p>
       </article>
     </div>
   </section>
@@ -65,7 +69,7 @@ const websiteSchema = {
   <section class="section index-feed" aria-labelledby="latest-works">
     <div class="section-heading">
       <p class="eyebrow">{t('home.latestWorksEyebrow')}</p>
-      <h2 id="latest-works">{t('home.latestWorksHeading')}</h2>
+      <h2 id="latest-works">Built records.</h2>
       <a class="text-link" href={withBase('/works/')}>{t('home.allWorks')}</a>
     </div>
 
@@ -111,7 +115,7 @@ const websiteSchema = {
   <section class="section index-feed" aria-labelledby="latest-notes">
     <div class="section-heading">
       <p class="eyebrow">{t('home.latestBlogEyebrow')}</p>
-      <h2 id="latest-notes">{t('home.latestBlogHeading')}</h2>
+      <h2 id="latest-notes">Field notes.</h2>
       <a class="text-link" href={withBase('/blog/')}>{t('home.allPosts')}</a>
     </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import { Image } from 'astro:assets';
 import { getCollection } from 'astro:content';
 import { withBase } from '../lib/url';
 import { SITE } from '../consts';
+import { formatDate, t } from '../i18n';
 
 const works = (await getCollection('works'))
   .sort((a, b) => {
@@ -18,13 +19,6 @@ const posts = (await getCollection('blog'))
   .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())
   .slice(0, 3);
 
-const formatDate = (date: Date) =>
-  new Intl.DateTimeFormat('en', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(date);
-
 const site = Astro.site ?? new URL(Astro.url.origin);
 const websiteSchema = {
   '@context': 'https://schema.org',
@@ -35,51 +29,44 @@ const websiteSchema = {
 };
 ---
 
-<BaseLayout
-  title="Astro Keel"
-  description="A minimal portfolio and writing theme for careful technical work."
->
+<BaseLayout description={t('home.description')}>
   <StructuredData slot="head" schema={websiteSchema} />
   <section class="hero section">
-    <p class="eyebrow">Portfolio / writing / systems notes</p>
-    <h1>Structural minimalism for careful digital work.</h1>
-    <p class="lead">
-      Astro Keel gives projects, essays, and professional notes a disciplined frame:
-      editorial type, measured rhythm, and a single accent carried through fine structural
-      rules.
-    </p>
-    <div class="action-row" aria-label="Primary links">
-      <a class="button" href={withBase('/works/')}>View works</a>
-      <a class="text-link" href={withBase('/blog/')}>Read notes</a>
+    <p class="eyebrow">{t('home.eyebrow')}</p>
+    <h1>{t('home.heading')}</h1>
+    <p class="lead">{t('home.lead')}</p>
+    <div class="action-row" aria-label={t('home.primaryLinks')}>
+      <a class="button" href={withBase('/works/')}>{t('home.viewWorks')}</a>
+      <a class="text-link" href={withBase('/blog/')}>{t('home.readNotes')}</a>
     </div>
   </section>
 
-  <section class="section split-overview" aria-label="Theme overview">
+  <section class="section split-overview" aria-label={t('home.overviewLabel')}>
     <div>
-      <p class="eyebrow">Principles</p>
-      <h2>Readable first, decorative last.</h2>
+      <p class="eyebrow">{t('home.principlesEyebrow')}</p>
+      <h2>{t('home.principlesHeading')}</h2>
     </div>
     <div class="feature-list">
       <article>
-        <h3>Baseline rhythm</h3>
-        <p>Vertical spacing follows a steady cadence for long-form reading.</p>
+        <h3>{t('home.principleRhythmTitle')}</h3>
+        <p>{t('home.principleRhythmBody')}</p>
       </article>
       <article>
-        <h3>Typed content</h3>
-        <p>Collections are prepared for project case studies and durable notes.</p>
+        <h3>{t('home.principleContentTitle')}</h3>
+        <p>{t('home.principleContentBody')}</p>
       </article>
       <article>
-        <h3>Keel lines</h3>
-        <p>Fine rules create structure without relying on decorative effects.</p>
+        <h3>{t('home.principleLinesTitle')}</h3>
+        <p>{t('home.principleLinesBody')}</p>
       </article>
     </div>
   </section>
 
   <section class="section index-feed" aria-labelledby="latest-works">
     <div class="section-heading">
-      <p class="eyebrow">Latest works</p>
-      <h2 id="latest-works">Built records.</h2>
-      <a class="text-link" href={withBase('/works/')}>All works</a>
+      <p class="eyebrow">{t('home.latestWorksEyebrow')}</p>
+      <h2 id="latest-works">{t('home.latestWorksHeading')}</h2>
+      <a class="text-link" href={withBase('/works/')}>{t('home.allWorks')}</a>
     </div>
 
     {
@@ -97,13 +84,13 @@ const websiteSchema = {
                 />
               )}
               <div>
-                <p class="meta">{formatDate(work.data.publishDate)}</p>
+                <p class="meta">{formatDate(work.data.publishDate, 'short')}</p>
                 <h3>
                   <a href={withBase(`/works/${work.id}/`)}>{work.data.title}</a>
                 </h3>
                 <p>{work.data.description}</p>
                 {work.data.tech.length > 0 && (
-                  <ul class="tag-list" aria-label={`${work.data.title} technology`}>
+                  <ul class="tag-list" aria-label={t('home.workTech', { title: work.data.title })}>
                     {work.data.tech.slice(0, 4).map((tech) => (
                       <li>{tech}</li>
                     ))}
@@ -115,7 +102,7 @@ const websiteSchema = {
         </div>
       ) : (
         <div class="empty-state compact">
-          <p>Add works under <code>src/content/works</code> to surface the latest projects here.</p>
+          <p set:html={t('home.worksEmpty')} />
         </div>
       )
     }
@@ -123,9 +110,9 @@ const websiteSchema = {
 
   <section class="section index-feed" aria-labelledby="latest-notes">
     <div class="section-heading">
-      <p class="eyebrow">Latest blog</p>
-      <h2 id="latest-notes">Field notes.</h2>
-      <a class="text-link" href={withBase('/blog/')}>All posts</a>
+      <p class="eyebrow">{t('home.latestBlogEyebrow')}</p>
+      <h2 id="latest-notes">{t('home.latestBlogHeading')}</h2>
+      <a class="text-link" href={withBase('/blog/')}>{t('home.allPosts')}</a>
     </div>
 
     {
@@ -143,7 +130,7 @@ const websiteSchema = {
                 />
               )}
               <div>
-                <p class="meta">{formatDate(post.data.publishDate)}</p>
+                <p class="meta">{formatDate(post.data.publishDate, 'short')}</p>
                 <h3>
                   <a href={withBase(`/blog/${post.id}/`)}>{post.data.title}</a>
                 </h3>
@@ -154,7 +141,7 @@ const websiteSchema = {
         </div>
       ) : (
         <div class="empty-state compact">
-          <p>Add blog entries under <code>src/content/blog</code> to surface the latest notes here.</p>
+          <p set:html={t('home.postsEmpty')} />
         </div>
       )
     }

--- a/src/pages/og/[collection]/[slug].png.ts
+++ b/src/pages/og/[collection]/[slug].png.ts
@@ -5,7 +5,6 @@ import { createRequire } from 'node:module';
 import satori from 'satori';
 import sharp from 'sharp';
 import { SITE } from '../../../consts';
-import { t } from '../../../i18n';
 
 // Build-time generated Open Graph images for every blog post and work entry,
 // rendered in the theme's light palette (see global.css tokens). The static
@@ -26,7 +25,7 @@ export const getStaticPaths = (async () => {
       props: {
         title: entry.data.title,
         description: entry.data.description,
-        kind: t('og.blog'),
+        kind: 'Blog',
       } satisfies OgProps,
     })),
     ...works.map((entry) => ({
@@ -34,7 +33,7 @@ export const getStaticPaths = (async () => {
       props: {
         title: entry.data.title,
         description: entry.data.description,
-        kind: t('og.work'),
+        kind: 'Work',
       } satisfies OgProps,
     })),
   ];
@@ -54,10 +53,11 @@ const require = createRequire(import.meta.url);
 const font = (pkgPath: string) => readFile(require.resolve(pkgPath));
 
 // Latin subsets, to keep the build light. Satori draws any glyph these fonts
-// lack as an empty box, so a site writing in a non-Latin script — including a
-// `SITE.locale` like `ja` — must swap in a face that covers it (install e.g.
-// `@fontsource/noto-sans-jp` and point the paths below at it). Post titles are
-// affected the same way, independently of the locale setting.
+// lack as an empty box, which is why the `kind` labels above stay Latin rather
+// than going through the UI dictionary — `SITE.locale = 'ja'` would otherwise
+// render them as tofu in every share image. Post titles in a non-Latin script
+// hit the same limit: install a face that covers them (e.g.
+// `@fontsource/noto-sans-jp`) and point the paths below at it.
 const [fraunces, publicSans] = await Promise.all([
   font('@fontsource/fraunces/files/fraunces-latin-600-normal.woff'),
   font('@fontsource/public-sans/files/public-sans-latin-400-normal.woff'),

--- a/src/pages/og/[collection]/[slug].png.ts
+++ b/src/pages/og/[collection]/[slug].png.ts
@@ -5,6 +5,7 @@ import { createRequire } from 'node:module';
 import satori from 'satori';
 import sharp from 'sharp';
 import { SITE } from '../../../consts';
+import { t } from '../../../i18n';
 
 // Build-time generated Open Graph images for every blog post and work entry,
 // rendered in the theme's light palette (see global.css tokens). The static
@@ -25,7 +26,7 @@ export const getStaticPaths = (async () => {
       props: {
         title: entry.data.title,
         description: entry.data.description,
-        kind: 'Blog',
+        kind: t('og.blog'),
       } satisfies OgProps,
     })),
     ...works.map((entry) => ({
@@ -33,7 +34,7 @@ export const getStaticPaths = (async () => {
       props: {
         title: entry.data.title,
         description: entry.data.description,
-        kind: 'Work',
+        kind: t('og.work'),
       } satisfies OgProps,
     })),
   ];
@@ -52,6 +53,11 @@ const COLOR = {
 const require = createRequire(import.meta.url);
 const font = (pkgPath: string) => readFile(require.resolve(pkgPath));
 
+// Latin subsets, to keep the build light. Satori draws any glyph these fonts
+// lack as an empty box, so a site writing in a non-Latin script — including a
+// `SITE.locale` like `ja` — must swap in a face that covers it (install e.g.
+// `@fontsource/noto-sans-jp` and point the paths below at it). Post titles are
+// affected the same way, independently of the locale setting.
 const [fraunces, publicSans] = await Promise.all([
   font('@fontsource/fraunces/files/fraunces-latin-600-normal.woff'),
   font('@fontsource/public-sans/files/public-sans-latin-400-normal.woff'),

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
 import { withBase } from '../lib/url';
 import { SITE } from '../consts';
+import { locale } from '../i18n';
 
 export async function GET(context: APIContext) {
   const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
@@ -13,6 +14,8 @@ export async function GET(context: APIContext) {
     title: SITE.title,
     description: SITE.rssDescription,
     site: context.site ?? 'https://example.com',
+    // Feed readers use <language> to pick a reading direction and hyphenation.
+    customData: `<language>${locale}</language>`,
     items: posts.map((post) => ({
       title: post.data.title,
       description: post.data.description,

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,26 +1,23 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { withBase } from '../lib/url';
+import { SITE } from '../consts';
+import { t } from '../i18n';
 
 const bundlePath = withBase('/pagefind/');
 ---
 
-<BaseLayout title="Search" description="Search posts and works — Astro Keel.">
+<BaseLayout title={t('search.title')} description={t('search.description', { site: SITE.title })}>
   <link slot="head" rel="stylesheet" href={`${bundlePath}pagefind-ui.css`} />
   <section class="page-head section">
-    <p class="eyebrow">Search</p>
-    <h1>Find posts and works.</h1>
-    <p class="lead">
-      Fully static search powered by Pagefind — indexed at build time, no backend required.
-    </p>
+    <p class="eyebrow">{t('search.eyebrow')}</p>
+    <h1>{t('search.heading')}</h1>
+    <p class="lead">{t('search.lead')}</p>
   </section>
 
-  <section class="section search-section" aria-label="Site search">
+  <section class="section search-section" aria-label={t('search.sectionLabel')}>
     <div id="search" data-bundle-path={bundlePath}>
-      <p class="search-fallback">
-        The search index is generated at build time. Run <code>npm run build</code> and
-        preview the site to try it — it is not available on the dev server.
-      </p>
+      <p class="search-fallback" set:html={t('search.fallback')} />
     </div>
     <script is:inline data-astro-rerun>
       // `data-astro-rerun` re-runs this after each soft navigation, because the

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -7,12 +7,14 @@ import { t } from '../i18n';
 const bundlePath = withBase('/pagefind/');
 ---
 
-<BaseLayout title={t('search.title')} description={t('search.description', { site: SITE.title })}>
+<BaseLayout title={t('search.title')} description={`Search posts and works — ${SITE.title}.`}>
   <link slot="head" rel="stylesheet" href={`${bundlePath}pagefind-ui.css`} />
   <section class="page-head section">
     <p class="eyebrow">{t('search.eyebrow')}</p>
-    <h1>{t('search.heading')}</h1>
-    <p class="lead">{t('search.lead')}</p>
+    <h1>Find posts and works.</h1>
+    <p class="lead">
+      Fully static search powered by Pagefind — indexed at build time, no backend required.
+    </p>
   </section>
 
   <section class="section search-section" aria-label={t('search.sectionLabel')}>

--- a/src/pages/works/[slug].astro
+++ b/src/pages/works/[slug].astro
@@ -3,6 +3,7 @@ import { getCollection, render } from 'astro:content';
 import { Image } from 'astro:assets';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { withBase } from '../../lib/url';
+import { formatDate, t } from '../../i18n';
 
 export async function getStaticPaths() {
   const entries = await getCollection('works');
@@ -11,13 +12,6 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
-
-const formatDate = (date: Date) =>
-  new Intl.DateTimeFormat('en', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(date);
 ---
 
 <BaseLayout
@@ -28,7 +22,7 @@ const formatDate = (date: Date) =>
 >
   <article data-pagefind-body>
     <header class="page-head section article-head">
-      <p class="eyebrow">Work</p>
+      <p class="eyebrow">{t('work.eyebrow')}</p>
       <h1>{entry.data.title}</h1>
       <p class="lead">{entry.data.description}</p>
       <div class="entry-meta">
@@ -36,8 +30,8 @@ const formatDate = (date: Date) =>
         <span>{entry.data.tech.join(' / ')}</span>
       </div>
       <div class="action-row">
-        {entry.data.link && <a class="button" href={entry.data.link}>Visit project</a>}
-        {entry.data.repo && <a class="text-link" href={entry.data.repo}>View repository</a>}
+        {entry.data.link && <a class="button" href={entry.data.link}>{t('work.visit')}</a>}
+        {entry.data.repo && <a class="text-link" href={entry.data.repo}>{t('work.repository')}</a>}
       </div>
       {
         entry.data.thumbnail && (
@@ -54,7 +48,7 @@ const formatDate = (date: Date) =>
 
     <div class="section article-layout">
       <aside class="article-toc">
-        <p class="eyebrow">Stack</p>
+        <p class="eyebrow">{t('work.stackEyebrow')}</p>
         <ul class="tech-list">
           {entry.data.tech.map((item) => <li>{item}</li>)}
         </ul>

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -2,6 +2,8 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { withBase } from '../../lib/url';
+import { SITE } from '../../consts';
+import { t } from '../../i18n';
 
 const works = (await getCollection('works')).sort((a, b) => {
   const orderA = a.data.order ?? Number.MAX_SAFE_INTEGER;
@@ -11,17 +13,14 @@ const works = (await getCollection('works')).sort((a, b) => {
 });
 ---
 
-<BaseLayout title="Works" description="Selected projects and case studies — Astro Keel.">
+<BaseLayout title={t('works.title')} description={t('works.description', { site: SITE.title })}>
   <section class="page-head section">
-    <p class="eyebrow">Works</p>
-    <h1>Selected projects and case studies.</h1>
-    <p class="lead">
-      The works collection is typed for descriptions, technology lists, external links,
-      repositories, thumbnails, ordering, and publish dates.
-    </p>
+    <p class="eyebrow">{t('works.eyebrow')}</p>
+    <h1>{t('works.heading')}</h1>
+    <p class="lead">{t('works.lead')}</p>
   </section>
 
-  <section class="section" aria-label="Selected works">
+  <section class="section" aria-label={t('works.listLabel')}>
     <div class="work-list">
       {
         works.map((work) => (

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -13,11 +13,14 @@ const works = (await getCollection('works')).sort((a, b) => {
 });
 ---
 
-<BaseLayout title={t('works.title')} description={t('works.description', { site: SITE.title })}>
+<BaseLayout title={t('works.title')} description={`Selected projects and case studies — ${SITE.title}.`}>
   <section class="page-head section">
     <p class="eyebrow">{t('works.eyebrow')}</p>
-    <h1>{t('works.heading')}</h1>
-    <p class="lead">{t('works.lead')}</p>
+    <h1>Selected projects and case studies.</h1>
+    <p class="lead">
+      The works collection is typed for descriptions, technology lists, external links,
+      repositories, thumbnails, ordering, and publish dates.
+    </p>
   </section>
 
   <section class="section" aria-label={t('works.listLabel')}>


### PR DESCRIPTION
## What

i18n Phase 1 — every UI string the theme renders moves into a typed dictionary under `src/i18n/`, driven by a new `SITE.locale`.

Closes #17 (Phase 1). Phase 2 — multi-language content routes — is split out into a follow-up issue.

## Why

All chrome was hard-coded English. One `SITE.locale` line now switches the strings, `<html lang>`, date formats, and the RSS `<language>` element, with no template edits.

## How

- **`src/i18n/en.ts`** — the reference dictionary and the source of the `UIStrings` type. Flat dotted keys, `{name}` placeholders. Values are deliberately not `as const`, which is what lets other locales satisfy the type.
- **`src/i18n/ja.ts`** — a full Japanese translation, typed as `UIStrings`, so a missing or misspelled key is a build error rather than a silent English fallback.
- **`src/i18n/index.ts`** — `t(key, params?)`, `formatDate(date, 'long' | 'short')`, `locale`, and `navLabel()`. Regional tags fall back to the base language's strings (`en-GB` → `en`) while keeping their own date format, so a variant only needs a file if the wording differs.
- **`src/consts.ts`** — `SITE.locale`, plus `NavItem` with `labelKey` (dictionary) or `label` (literal, for pages you add yourself).
- **Templates** — layout, pagination, social links, home, about, search, 404, blog index, tag archive, blog post, works index, work detail, RSS, and the OG image route all read from the dictionary. The five duplicated `Intl.DateTimeFormat` helpers collapse into the shared `formatDate`.

Three strings carry inline `<code>` markup (the two empty states and the search fallback); those render with `set:html`. They are theme-authored, never user input.

## Scope

The dictionary covers everything the *theme* renders — chrome, aria labels, page titles and meta descriptions, and the placeholder copy on the built-in pages. Content-collection entries (your posts and works) stay in Markdown, as they should.

## Verification

`npm run check` 0 errors (4 pre-existing hints), `npm run build` succeeds.

**No regression at `locale: 'en'`** — every generated HTML page is byte-identical to `main`. The only diff in the whole `dist/` is the added `<language>en</language>` in `rss.xml`.

**With `locale: 'ja'`**, a full build gives:

| | Output |
| --- | --- |
| `<html lang>` | `ja` |
| Nav | ホーム \| プロフィール \| 制作物 \| ブログ \| 検索 |
| Hero | 丁寧なデジタルワークのための、構造的ミニマリズム。 |
| Buttons | 制作物を見る / ノートを読む |
| Date (short) | `2026年3月9日` — field order from `Intl`, not a format string |
| Post nav | 次の記事 |
| 404 | このページは航路から外れました。 |
| RSS | `<language>ja</language>` |

## Known limitation — OG images and non-Latin scripts

The generated OG images bundle **Latin subsets** of Fraunces and Public Sans to keep builds light, and Satori draws any missing glyph as an empty box. With `locale: 'ja'` the `Blog` / `Work` label renders as boxes.

This is pre-existing and not specific to the label: a Japanese *post title* has always rendered the same way. Rather than add a multi-megabyte CJK font to a minimal theme's dependencies, this PR documents the swap — a code comment at the font-loading site and a note in the README pointing at `@fontsource/noto-sans-jp`. The shipped default (`en`) is unaffected.

## Screenshots

No visual change at the default `locale: 'en'` — the HTML is identical to `main`.

## Checklist

- [x] `npm run check` passes (0 errors, 4 pre-existing hints)
- [x] `npm run build` succeeds
- [x] Verified in both light and dark mode — no style changes in this PR
- [x] New config options documented in `src/consts.ts` comments and the README
- [x] No new client-side weight (all resolution happens at build time)
