### PR TITLE
ci: validate pull requests with astro check and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  # Keep main verified too, so a green branch that goes stale is caught on merge.
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Superseded pushes to the same ref don't need to finish.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          # Astro 7 requires Node >=22.12.0; keep in sync with deploy.yml.
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Type-check
+        run: npm run check
+      - name: Build
+        # Also exercises the postbuild Pagefind index step.
+        run: npm run build


### PR DESCRIPTION
Closes #26.

これまでワークフローは `deploy.yml` だけで、PR には一切チェックがかかっていなかった。型エラーやビルド破損は main にマージして Pages デプロイが落ちて初めて発覚する状態だった。

## 変更

- `.github/workflows/ci.yml` を新規追加
  - トリガー: `pull_request` と `push: [main]`（グリーンのまま古くなったブランチをマージ時に検知するため）
  - checkout → `actions/setup-node` (Node 22, `cache: npm`) → `npm ci` → `npm run check` → `npm run build`
  - build は `postbuild` の Pagefind インデックス生成も通る
  - `concurrency: ci-${{ github.ref }}` + `cancel-in-progress: true` で古い push の実行を打ち切る
  - `permissions` は `contents: read` のみ
- `deploy.yml` は未変更。デプロイはデプロイ、CI は検証と役割を分ける

## 確認

ローカルで `npm run check` (exit 0 / errors 0)、`npm run build` (Pagefind まで成功) を確認済み。

## フォローアップ（コード外）

マージ後、リポジトリ設定で `check` ジョブを main の required status check に指定する。