### PR TITLE
ci: enable Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Routine bumps arrive as one reviewable PR; majors stay separate so a
+      # breaking change is never buried in a batch.
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
Closes #27. #26 に依存（マージ済み）。

`.github/dependabot.yml` がなかったため、依存は手で上げない限り止まったまま。テーマとしては二重に効いてくる問題で、リポジトリ自体が古びるうえ、テンプレートを clone した人も古いバージョンから始めることになる。Actions のピン (`actions/checkout@v4`, `withastro/action@v3`) も同様に放置される。

## 変更

`.github/dependabot.yml` を新規追加。週次で2系統。

- **npm** — minor + patch を `npm-minor-patch` グループにまとめて1 PR に。major は個別 PR のまま残し、破壊的変更がバッチに埋もれないようにする。commit prefix は `chore`（scope 付き）
- **github-actions** — 全部を1グループに。commit prefix は `ci`

両方とも `open-pull-requests-limit: 5`。

## 確認

YAML のパースを確認済み。実際の PR 生成は Dependabot 側のスケジュール実行なので、マージ後に Insights → Dependency graph → Dependabot で初回実行を確認する。

## 期待する動作

マージ後、Dependabot のグループ PR には #26 の CI が自動で走る。minor/patch バッチはグリーンなら手動テストなしでマージ可。