### PR TITLE
chore: adopt Prettier with prettier-plugin-astro

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+# Markdown uses trailing whitespace for hard line breaks.
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Prettier normalises to LF, so the checked-out tree has to be LF everywhere.
+# Without this, a Windows clone (Git for Windows defaults to core.autocrlf=true)
+# converts on checkout and `npm run format:check` fails on every file — a
+# failure CI never reproduces, because CI runs on Linux.
+* text=auto eol=lf
+
+# Assets: never normalise, never diff as text.
+*.png binary
+*.jpg binary
+*.ico binary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,6 @@ updates:
     groups:
       actions:
         patterns:
-          - "*"
+          - '*'
     commit-message:
       prefix: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Check formatting
+        # Before the slower steps: a formatting miss is the cheapest failure to
+        # surface, and `npm run format` is the whole fix.
+        run: npm run format:check
       - name: Type-check
         run: npm run check
       - name: Build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,12 @@
+dist/
+node_modules/
+package-lock.json
+
+# Release notes are hand-formatted; reflowing them churns every entry.
+CHANGELOG.md
+
+# prettier-plugin-astro cannot parse a <style> whose children are a JSX
+# expression, which is the only way to write scoped CSS inside `{enabled && …}`.
+# Rewriting it as `set:html` would move the CSS out of the markup just to satisfy
+# the formatter — drop this line once the plugin handles the construct.
+src/components/Comments.astro

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "plugins": ["prettier-plugin-astro"],
+  "singleQuote": true,
+  "printWidth": 100,
+  "overrides": [
+    {
+      "files": "*.astro",
+      "options": { "parser": "astro" }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ written with that in mind — each one names the files it touches.
 
 ## [Unreleased]
 
+### Added
+
+- **Prettier** with `prettier-plugin-astro` (`.prettierrc`, `.prettierignore`),
+  plus `npm run format` / `npm run format:check` and a formatting gate in CI.
+  Settings match the existing code — single quotes, 100-column lines — so
+  porting this into your own copy reflows rather than rewrites it.
+  `src/components/Comments.astro` is excluded: the plugin cannot parse its
+  expression-wrapped `<style>`.
+- **`.editorconfig`** covering charset, line endings, and indentation for
+  editors that do not run Prettier.
+
+### Changed
+
+- The tree is now Prettier-formatted. No behaviour changed — the diff is quote
+  style, wrapping, and Markdown emphasis syntax.
+
 ## [0.2.0] - 2026-08-03
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ npm run build    # must succeed; also runs `pagefind` via postbuild
 
 `npm run check` currently emits four hints: two Zod deprecations from Astro's
 content schema API, and two unused-`Props` hints in the paginated routes. Those
-are pre-existing — new *errors* are not acceptable, new hints should be avoided.
+are pre-existing — new _errors_ are not acceptable, new hints should be avoided.
 
 ## Project structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ Pages demo. Leave it as-is in PRs; downstream users drop it for a root domain.
 Before pushing:
 
 ```sh
+npm run format   # Prettier — CI rejects unformatted code
 npm run check    # astro check — must report 0 errors
 npm run build    # must succeed; also runs `pagefind` via postbuild
 ```
@@ -42,6 +43,21 @@ npm run build    # must succeed; also runs `pagefind` via postbuild
 `npm run check` currently emits four hints: two Zod deprecations from Astro's
 content schema API, and two unused-`Props` hints in the paginated routes. Those
 are pre-existing — new _errors_ are not acceptable, new hints should be avoided.
+
+## Formatting
+
+Prettier owns formatting, with `prettier-plugin-astro` for `.astro` files.
+`npm run format:check` runs in CI, so an unformatted PR fails before the build.
+Don't hand-tune style — run `npm run format` and let the config decide.
+
+Settings live in `.prettierrc`: single quotes and 100-column lines, chosen to
+match the code as it was already written. `.editorconfig` covers charset, line
+endings, and indentation for editors that don't run Prettier.
+
+Two paths are exempt in `.prettierignore`: `CHANGELOG.md`, whose entries are
+hand-wrapped, and `src/components/Comments.astro`, which the Astro plugin cannot
+parse — its `<style>` is wrapped in a JSX expression, the only way to scope CSS
+inside `{enabled && …}`. Keep that file tidy by hand.
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ A calm neutral base, a single configurable accent color, generous whitespace, an
 Every page of the demo scores **100 across all four categories** — with search,
 pagination, and generated OG images all switched on.
 
-| Page | Performance | Accessibility | Best Practices | SEO |
-| --- | :---: | :---: | :---: | :---: |
-| Home `/` | 100 | 100 | 100 | 100 |
-| Blog index `/blog/` | 100 | 100 | 100 | 100 |
-| Blog post `/blog/baseline-rhythm/` | 100 | 100 | 100 | 100 |
-| Works `/works/` | 100 | 100 | 100 | 100 |
-| Search `/search/` | 100 | 100 | 100 | 100 |
+| Page                               | Performance | Accessibility | Best Practices | SEO |
+| ---------------------------------- | :---------: | :-----------: | :------------: | :-: |
+| Home `/`                           |     100     |      100      |      100       | 100 |
+| Blog index `/blog/`                |     100     |      100      |      100       | 100 |
+| Blog post `/blog/baseline-rhythm/` |     100     |      100      |      100       | 100 |
+| Works `/works/`                    |     100     |      100      |      100       | 100 |
+| Search `/search/`                  |     100     |      100      |      100       | 100 |
 
 <sub>Lighthouse 13.4.1, desktop preset, local production build. Reproduce it yourself:</sub>
 
@@ -229,10 +229,10 @@ To turn it on:
 export const GISCUS: GiscusConfig = {
   enabled: true,
   repo: '<user>/<repo>',
-  repoId: 'R_...',        // from giscus.app
+  repoId: 'R_...', // from giscus.app
   category: 'Announcements',
-  categoryId: 'DIC_...',  // from giscus.app
-  mapping: 'pathname',    // survives retitling, unlike 'title'
+  categoryId: 'DIC_...', // from giscus.app
+  mapping: 'pathname', // survives retitling, unlike 'title'
   // ...
 };
 ```
@@ -301,11 +301,11 @@ Add Markdown/MDX files under `src/content/`:
 ---
 title: Project name
 description: One-line summary.
-tech: ["Astro", "TypeScript"]
-link: https://example.com        # optional — live link
-repo: https://github.com/...     # optional — source
-thumbnail: ./cover.png           # optional — relative image
-order: 1                         # optional — manual sort
+tech: ['Astro', 'TypeScript']
+link: https://example.com # optional — live link
+repo: https://github.com/... # optional — source
+thumbnail: ./cover.png # optional — relative image
+order: 1 # optional — manual sort
 publishDate: 2026-06-01
 ---
 ```
@@ -317,9 +317,9 @@ publishDate: 2026-06-01
 title: Post title
 publishDate: 2026-06-01
 description: One-line summary for listings, SEO, and RSS.
-tags: ["design", "astro"]
-draft: false                     # true hides it from build output
-heroImage: ./hero.png            # optional — relative image
+tags: ['design', 'astro']
+draft: false # true hides it from build output
+heroImage: ./hero.png # optional — relative image
 ---
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-keel",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-keel",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@astrojs/mdx": "^7.0.0",
         "@astrojs/rss": "^4.0.18",
@@ -22,6 +22,8 @@
         "@astrojs/check": "^0.9.9",
         "@fontsource/fraunces": "^5.2.9",
         "pagefind": "^1.5.2",
+        "prettier": "^3.9.6",
+        "prettier-plugin-astro": "^0.14.1",
         "satori": "^0.26.0",
         "sharp": "^0.35.3",
         "typescript": "^6.0.3"
@@ -6430,9 +6432,9 @@
       "license": "MIT"
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6443,6 +6445,21 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-astro": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
+      "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.9.1",
+        "prettier": "^3.0.0",
+        "sass-formatter": "^0.7.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/prismjs": {
@@ -6890,6 +6907,23 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
     },
+    "node_modules/s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sass-formatter": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
+      "integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "suf-log": "^2.5.3"
+      }
+    },
     "node_modules/satori": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/satori/-/satori-0.26.0.tgz",
@@ -7176,6 +7210,16 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "s.color": "0.0.15"
       }
     },
     "node_modules/svgo": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "postbuild": "pagefind --site dist",
     "preview": "astro preview",
     "check": "astro check",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "astro": "astro"
   },
   "dependencies": {
@@ -28,6 +30,8 @@
     "@astrojs/check": "^0.9.9",
     "@fontsource/fraunces": "^5.2.9",
     "pagefind": "^1.5.2",
+    "prettier": "^3.9.6",
+    "prettier-plugin-astro": "^0.14.1",
     "satori": "^0.26.0",
     "sharp": "^0.35.3",
     "typescript": "^6.0.3"

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -11,8 +11,7 @@ const { page } = Astro.props;
 // `paginate()` already prepends the configured `base`; just normalise the
 // trailing slash so links match the rest of the site and skip the
 // GitHub Pages directory redirect.
-const withSlash = (url: string | undefined) =>
-  url && (url.endsWith('/') ? url : `${url}/`);
+const withSlash = (url: string | undefined) => url && (url.endsWith('/') ? url : `${url}/`);
 
 const prev = withSlash(page.url.prev);
 const next = withSlash(page.url.next);
@@ -21,11 +20,23 @@ const next = withSlash(page.url.next);
 {
   page.lastPage > 1 && (
     <nav class="pagination" aria-label={t('pagination.label')}>
-      {prev ? <a href={prev} rel="prev">{t('pagination.newer')}</a> : <span aria-hidden="true" />}
+      {prev ? (
+        <a href={prev} rel="prev">
+          {t('pagination.newer')}
+        </a>
+      ) : (
+        <span aria-hidden="true" />
+      )}
       <span class="pagination-status">
         {t('pagination.status', { current: page.currentPage, total: page.lastPage })}
       </span>
-      {next ? <a href={next} rel="next">{t('pagination.older')}</a> : <span aria-hidden="true" />}
+      {next ? (
+        <a href={next} rel="next">
+          {t('pagination.older')}
+        </a>
+      ) : (
+        <span aria-hidden="true" />
+      )}
     </nav>
   )
 }

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -13,8 +13,7 @@ const ICONS: Record<SocialIcon, string> = {
   linkedin:
     '<rect x="4" y="4" width="16" height="16" rx="2"/><path d="M8 11v5"/><path d="M8 8v.01"/><path d="M12 16v-5"/><path d="M16 16v-3a2 2 0 0 0 -4 0"/>',
   rss: '<circle cx="5" cy="19" r="1"/><path d="M4 4a16 16 0 0 1 16 16"/><path d="M4 11a9 9 0 0 1 9 9"/>',
-  email:
-    '<rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6l9 -6"/>',
+  email: '<rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6l9 -6"/>',
 };
 
 const isInternal = (href: string) => href.startsWith('/');

--- a/src/content/blog/baseline-rhythm.mdx
+++ b/src/content/blog/baseline-rhythm.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Designing with a Baseline Grid"
+title: 'Designing with a Baseline Grid'
 publishDate: 2026-01-14
 tags:
   - design
   - process
-description: "A short note on giving long-form pages a quiet vertical cadence."
+description: 'A short note on giving long-form pages a quiet vertical cadence.'
 heroImage: ./blog-hero.jpg
 draft: false
 ---

--- a/src/content/blog/content-layer-notes.md
+++ b/src/content/blog/content-layer-notes.md
@@ -1,10 +1,10 @@
 ---
-title: "Content Layer Notes"
+title: 'Content Layer Notes'
 publishDate: 2026-02-03
 tags:
   - astro
   - content
-description: "Practical notes for keeping Astro content collections predictable."
+description: 'Practical notes for keeping Astro content collections predictable.'
 draft: false
 ---
 

--- a/src/content/blog/release-checklist.md
+++ b/src/content/blog/release-checklist.md
@@ -1,10 +1,10 @@
 ---
-title: "A Small Release Checklist"
+title: 'A Small Release Checklist'
 publishDate: 2026-03-18
 tags:
   - process
   - release
-description: "A compact checklist for shipping a portfolio update without drama."
+description: 'A compact checklist for shipping a portfolio update without drama.'
 draft: false
 ---
 

--- a/src/content/works/code-reading-kit.mdx
+++ b/src/content/works/code-reading-kit.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Code Reading Kit"
-description: "A documentation pattern for explaining implementation decisions through concise examples and annotated prose."
+title: 'Code Reading Kit'
+description: 'A documentation pattern for explaining implementation decisions through concise examples and annotated prose.'
 thumbnail: ./code-reading-kit.jpg
 tech:
   - MDX

--- a/src/content/works/field-notes-archive.md
+++ b/src/content/works/field-notes-archive.md
@@ -1,6 +1,6 @@
 ---
-title: "Field Notes Archive"
-description: "A searchable writing archive organized around tags, dates, and compact editorial summaries."
+title: 'Field Notes Archive'
+description: 'A searchable writing archive organized around tags, dates, and compact editorial summaries.'
 thumbnail: ./field-notes-archive.jpg
 tech:
   - Astro

--- a/src/content/works/keel-portfolio.md
+++ b/src/content/works/keel-portfolio.md
@@ -1,13 +1,13 @@
 ---
-title: "Keel Portfolio System"
-description: "A lean portfolio structure for project studies, writing, and durable personal documentation."
+title: 'Keel Portfolio System'
+description: 'A lean portfolio structure for project studies, writing, and durable personal documentation.'
 thumbnail: ./keel-portfolio.jpg
 tech:
   - Astro
   - Content Collections
   - CSS Variables
-link: "https://example.com"
-repo: "https://github.com/example/keel-portfolio"
+link: 'https://example.com'
+repo: 'https://github.com/example/keel-portfolio'
 order: 1
 publishDate: 2026-01-22
 ---

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -52,7 +52,9 @@ export const t = (key: UIKey, params?: Record<string, string | number>): string 
  * rebuilt, instead of showing either kind of garbage.
  */
 export const readingTime = (minutesRead: unknown): string =>
-  typeof minutesRead === 'number' ? t('post.readingTime', { minutes: minutesRead }) : String(minutesRead ?? '');
+  typeof minutesRead === 'number'
+    ? t('post.readingTime', { minutes: minutesRead })
+    : String(minutesRead ?? '');
 
 /** Format a publish date in the active locale. `long` spells the month out;
  *  `short` abbreviates it. Both are locale-aware, including field order. */

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,12 +22,7 @@ interface Props {
 
 const siteName = SITE.title;
 
-const {
-  title = siteName,
-  description = SITE.description,
-  ogType = 'website',
-  image,
-} = Astro.props;
+const { title = siteName, description = SITE.description, ogType = 'website', image } = Astro.props;
 
 // `Astro.site` comes from `site` in astro.config.mjs; fall back to the
 // request URL during dev so canonical/OG links still resolve.

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -8,13 +8,16 @@ import { SITE } from '../../consts';
 import { t } from '../../i18n';
 ---
 
-<BaseLayout title={t('about.title')} description={`About the author behind this ${SITE.title} site.`}>
+<BaseLayout
+  title={t('about.title')}
+  description={`About the author behind this ${SITE.title} site.`}
+>
   <section class="page-head section">
     <p class="eyebrow">{t('about.eyebrow')}</p>
     <h1>A measured profile for the person behind the work.</h1>
     <p class="lead">
-      This page is shaped for a concise biography, a working philosophy, and the handful
-      of details that help readers understand how you think.
+      This page is shaped for a concise biography, a working philosophy, and the handful of details
+      that help readers understand how you think.
     </p>
   </section>
 
@@ -25,14 +28,13 @@ import { t } from '../../i18n';
     </div>
     <div class="prose-stack">
       <p>
-        I work across product strategy, interface systems, and technical writing. The
-        common thread is structure: making complex material easier to scan, trust, and
-        maintain.
+        I work across product strategy, interface systems, and technical writing. The common thread
+        is structure: making complex material easier to scan, trust, and maintain.
       </p>
       <p>
-        Astro Keel leaves room for this kind of context without forcing a loud personal
-        brand. Replace this placeholder with a specific background, current role, and
-        the constraints that shape your work.
+        Astro Keel leaves room for this kind of context without forcing a loud personal brand.
+        Replace this placeholder with a specific background, current role, and the constraints that
+        shape your work.
       </p>
     </div>
   </section>
@@ -47,12 +49,17 @@ import { t } from '../../i18n';
       <article>
         <span>02</span>
         <h3>Background</h3>
-        <p>Experience spanning frontend implementation, design systems, and writing for technical audiences.</p>
+        <p>
+          Experience spanning frontend implementation, design systems, and writing for technical
+          audiences.
+        </p>
       </article>
       <article>
         <span>03</span>
         <h3>Contact</h3>
-        <p>Use this section for availability, collaboration preferences, or a direct contact route.</p>
+        <p>
+          Use this section for availability, collaboration preferences, or a direct contact route.
+        </p>
       </article>
     </div>
   </section>
@@ -64,9 +71,9 @@ import { t } from '../../i18n';
     </div>
     <div class="prose-stack">
       <p>
-        The theme treats the page like a working document: hierarchy first, rhythm second,
-        visual signature third. Fine rules, generous spacing, and type contrast carry the
-        identity without competing with the content.
+        The theme treats the page like a working document: hierarchy first, rhythm second, visual
+        signature third. Fine rules, generous spacing, and type contrast carry the identity without
+        competing with the content.
       </p>
     </div>
   </section>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -35,13 +35,16 @@ const pageTitle =
   page.currentPage === 1 ? t('blog.title') : t('blog.titlePaged', { page: page.currentPage });
 ---
 
-<BaseLayout title={pageTitle} description={`Notes and writing — ${SITE.title}, a minimal portfolio and blog theme for Astro.`}>
+<BaseLayout
+  title={pageTitle}
+  description={`Notes and writing — ${SITE.title}, a minimal portfolio and blog theme for Astro.`}
+>
   <section class="page-head section">
     <p class="eyebrow">{t('blog.eyebrow')}</p>
     <h1>Notes, essays, and release logs.</h1>
     <p class="lead">
-      The blog collection supports tags, descriptions, draft filtering, publish dates,
-      and optional hero images.
+      The blog collection supports tags, descriptions, draft filtering, publish dates, and optional
+      hero images.
     </p>
   </section>
 
@@ -59,11 +62,15 @@ const pageTitle =
           posts.map((post) => (
             <article class="entry-card">
               <div class="entry-meta">
-                <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate, 'short')}</time>
+                <time datetime={post.data.publishDate.toISOString()}>
+                  {formatDate(post.data.publishDate, 'short')}
+                </time>
                 <span>{readingTimes.get(post.id)}</span>
                 <span>{post.data.tags.join(' / ')}</span>
               </div>
-              <h2><a href={withBase(`/blog/${post.id}/`)}>{post.data.title}</a></h2>
+              <h2>
+                <a href={withBase(`/blog/${post.id}/`)}>{post.data.title}</a>
+              </h2>
               <p>{post.data.description}</p>
             </article>
           ))

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -64,7 +64,12 @@ const schema = [
     '@type': 'BreadcrumbList',
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: t('post.breadcrumbHome'), item: absolute('/') },
-      { '@type': 'ListItem', position: 2, name: t('post.breadcrumbBlog'), item: absolute('/blog/') },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: t('post.breadcrumbBlog'),
+        item: absolute('/blog/'),
+      },
       { '@type': 'ListItem', position: 3, name: entry.data.title },
     ],
   },
@@ -84,7 +89,9 @@ const schema = [
       <h1>{entry.data.title}</h1>
       <p class="lead">{entry.data.description}</p>
       <div class="entry-meta">
-        <time datetime={entry.data.publishDate.toISOString()}>{formatDate(entry.data.publishDate)}</time>
+        <time datetime={entry.data.publishDate.toISOString()}
+          >{formatDate(entry.data.publishDate)}</time
+        >
         <span>{readingTime(remarkPluginFrontmatter.minutesRead)}</span>
         <span>{entry.data.tags.join(' / ')}</span>
       </div>

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -62,11 +62,15 @@ const pageTitle =
           taggedPosts.map((post) => (
             <article class="entry-card">
               <div class="entry-meta">
-                <time datetime={post.data.publishDate.toISOString()}>{formatDate(post.data.publishDate, 'short')}</time>
+                <time datetime={post.data.publishDate.toISOString()}>
+                  {formatDate(post.data.publishDate, 'short')}
+                </time>
                 <span>{readingTimes.get(post.id)}</span>
                 <span>{post.data.tags.join(' / ')}</span>
               </div>
-              <h2><a href={withBase(`/blog/${post.id}/`)}>{post.data.title}</a></h2>
+              <h2>
+                <a href={withBase(`/blog/${post.id}/`)}>{post.data.title}</a>
+              </h2>
               <p>{post.data.description}</p>
             </article>
           ))

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,9 +35,8 @@ const websiteSchema = {
     <p class="eyebrow">Portfolio / writing / systems notes</p>
     <h1>Structural minimalism for careful digital work.</h1>
     <p class="lead">
-      Astro Keel gives projects, essays, and professional notes a disciplined frame:
-      editorial type, measured rhythm, and a single accent carried through fine structural
-      rules.
+      Astro Keel gives projects, essays, and professional notes a disciplined frame: editorial type,
+      measured rhythm, and a single accent carried through fine structural rules.
     </p>
     <div class="action-row" aria-label={t('home.primaryLinks')}>
       <a class="button" href={withBase('/works/')}>{t('home.viewWorks')}</a>
@@ -79,13 +78,7 @@ const websiteSchema = {
           {works.map((work) => (
             <article class="highlight-card">
               {work.data.thumbnail && (
-                <Image
-                  src={work.data.thumbnail}
-                  alt=""
-                  width={720}
-                  height={480}
-                  loading="lazy"
-                />
+                <Image src={work.data.thumbnail} alt="" width={720} height={480} loading="lazy" />
               )}
               <div>
                 <p class="meta">{formatDate(work.data.publishDate, 'short')}</p>
@@ -125,13 +118,7 @@ const websiteSchema = {
           {posts.map((post) => (
             <article class="note-row">
               {post.data.heroImage && (
-                <Image
-                  src={post.data.heroImage}
-                  alt=""
-                  width={320}
-                  height={220}
-                  loading="lazy"
-                />
+                <Image src={post.data.heroImage} alt="" width={320} height={220} loading="lazy" />
               )}
               <div>
                 <p class="meta">{formatDate(post.data.publishDate, 'short')}</p>

--- a/src/pages/works/[slug].astro
+++ b/src/pages/works/[slug].astro
@@ -26,12 +26,26 @@ const { Content } = await render(entry);
       <h1>{entry.data.title}</h1>
       <p class="lead">{entry.data.description}</p>
       <div class="entry-meta">
-        <time datetime={entry.data.publishDate.toISOString()}>{formatDate(entry.data.publishDate)}</time>
+        <time datetime={entry.data.publishDate.toISOString()}
+          >{formatDate(entry.data.publishDate)}</time
+        >
         <span>{entry.data.tech.join(' / ')}</span>
       </div>
       <div class="action-row">
-        {entry.data.link && <a class="button" href={entry.data.link}>{t('work.visit')}</a>}
-        {entry.data.repo && <a class="text-link" href={entry.data.repo}>{t('work.repository')}</a>}
+        {
+          entry.data.link && (
+            <a class="button" href={entry.data.link}>
+              {t('work.visit')}
+            </a>
+          )
+        }
+        {
+          entry.data.repo && (
+            <a class="text-link" href={entry.data.repo}>
+              {t('work.repository')}
+            </a>
+          )
+        }
       </div>
       {
         entry.data.thumbnail && (

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -13,7 +13,10 @@ const works = (await getCollection('works')).sort((a, b) => {
 });
 ---
 
-<BaseLayout title={t('works.title')} description={`Selected projects and case studies — ${SITE.title}.`}>
+<BaseLayout
+  title={t('works.title')}
+  description={`Selected projects and case studies — ${SITE.title}.`}
+>
   <section class="page-head section">
     <p class="eyebrow">{t('works.eyebrow')}</p>
     <h1>Selected projects and case studies.</h1>
@@ -29,7 +32,9 @@ const works = (await getCollection('works')).sort((a, b) => {
         works.map((work) => (
           <article class="work-card">
             <p class="entry-meta">{work.data.tech.join(' / ')}</p>
-            <h2><a href={withBase(`/works/${work.id}/`)}>{work.data.title}</a></h2>
+            <h2>
+              <a href={withBase(`/works/${work.id}/`)}>{work.data.title}</a>
+            </h2>
             <p>{work.data.description}</p>
           </article>
         ))

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,9 +13,9 @@
   --color-line: oklch(0.86 0.008 100);
   --color-line-strong: oklch(0.72 0.012 120);
   --color-soft: oklch(0.94 0.006 100);
-  --font-display: "Fraunces Variable", Georgia, serif;
-  --font-body: "Public Sans", system-ui, sans-serif;
-  --font-mono: "JetBrains Mono Variable", ui-monospace, monospace;
+  --font-display: 'Fraunces Variable', Georgia, serif;
+  --font-body: 'Public Sans', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono Variable', ui-monospace, monospace;
   --content-width: 1160px;
   --prose-width: 68ch;
   --page-pad: clamp(1rem, 3vw, 2rem);
@@ -223,7 +223,7 @@ a:not(.brand, .button):hover {
 }
 
 .hero::before {
-  content: "";
+  content: '';
   position: absolute;
   top: clamp(1.5rem, 3vw, 2.5rem);
   left: 0;
@@ -259,7 +259,7 @@ a:not(.brand, .button):hover {
 
 .page-head::after,
 .split-overview > div:first-child::after {
-  content: "";
+  content: '';
   display: block;
   width: 4.5rem;
   height: 1px;
@@ -281,7 +281,7 @@ a:not(.brand, .button):hover {
 }
 
 .eyebrow::before {
-  content: "";
+  content: '';
   width: 2.25rem;
   height: 1px;
   background: currentColor;
@@ -301,7 +301,10 @@ h2,
 h3 {
   max-width: 12.5ch;
   font-family: var(--font-display);
-  font-variation-settings: "opsz" 72, "SOFT" 20, "WONK" 1;
+  font-variation-settings:
+    'opsz' 72,
+    'SOFT' 20,
+    'WONK' 1;
   font-weight: 650;
   letter-spacing: 0;
 }
@@ -390,7 +393,7 @@ p {
 }
 
 .feature-list article::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0;
   left: clamp(1.5rem, 3vw, 2.25rem);
@@ -892,7 +895,7 @@ pre code {
 }
 
 .about-ledger article::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0;
   left: clamp(1.5rem, 3vw, 2.25rem);


### PR DESCRIPTION
Closes #28.

The repo had no formatter config, so `.astro` diffs varied by editor and
CONTRIBUTING.md had nothing enforceable to point at. This adds Prettier with the
official Astro plugin, formats the tree, and gates CI on it. ESLint is
deliberately not part of this — more than a theme template needs.

## Commits

Split so the mechanical churn is reviewable separately from the decisions:

1. `chore` — deps, `.prettierrc`, `.prettierignore`, `format` / `format:check` scripts
2. `chore` — `.editorconfig`
3. `style` — repo-wide `npm run format` (mechanical, no behaviour change)
4. `ci` — `format:check` step in the CI workflow
5. `docs` — formatting section in CONTRIBUTING.md
6. `docs` — CHANGELOG entries
7. `chore` — `.gitattributes` pinning LF, so Prettier's `endOfLine` still holds
   on a Windows clone (`core.autocrlf=true` would otherwise fail `format:check`
   on every file, and CI on Linux would never reproduce it)

## Config matches the existing code

Prettier's defaults (double quotes, 80 columns) rewrote the tree: 779 insertions
/ 573 deletions, including the quote style inside a demo post's code block.
The code as written uses single quotes 454 times to 5, and its 99th-percentile
line is 105 characters — so `singleQuote: true` and `printWidth: 100` bring
adoption down to **142 insertions / 101 deletions**. It reflows the tree instead
of rewriting it, which also keeps this PR from colliding with open work.

## Two files are exempt

- `CHANGELOG.md` — entries are hand-wrapped; reflowing churns all of them.
- `src/components/Comments.astro` — `prettier-plugin-astro` cannot parse a
  `<style>` whose children are a JSX expression, and that is the only way to
  scope CSS inside `{enabled && …}`. It fails with `CssSyntaxError` on the
  backtick. Rewriting it as `set:html` would move the CSS out of the markup
  purely to satisfy the formatter, so the file is ignored and CONTRIBUTING.md
  says to keep it tidy by hand. The line comes out once the plugin handles it.

## Verification

- `npm run format:check` exits 0 on a clean tree, and exits 1 with an
  unformatted file present — checked, not assumed.
- `npm run check` — 0 errors, 0 warnings, the same 4 pre-existing hints.
- `npm run build` succeeds, including the Pagefind `postbuild` step.
- Coverage: `.astro` 14/15, `.ts` 8/8, `.mjs` 2/2, `.md` 7/8, `.mdx` 2/2,
  `.css` 1/1 (the two gaps are the exemptions above).
- `git add --renormalize .` stages nothing, so pinning LF rewrites no existing
  file — the tree was already LF.
- `dist/` built from this branch is byte-identical to `dist/` built from `main`,
  across every page, the CSS bundle, the OG images, and the Pagefind index.

No visual change, so no screenshots — the only content edits are quote style in
frontmatter and `*errors*` → `_errors_` in Markdown emphasis.
