### PR TITLE
chore: Prettier設定のエディタDXを補強

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 100
 
 [*.md]
 # Markdown uses trailing whitespace for hard line breaks.

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,11 +1,5 @@
 {
   "plugins": ["prettier-plugin-astro"],
   "singleQuote": true,
-  "printWidth": 100,
-  "overrides": [
-    {
-      "files": "*.astro",
-      "options": { "parser": "astro" }
-    }
-  ]
+  "printWidth": 100
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "astro-build.astro-vscode"]
+}

--- a/README.md
+++ b/README.md
@@ -297,29 +297,31 @@ Add Markdown/MDX files under `src/content/`:
 
 ### Works frontmatter
 
+<!-- prettier-ignore -->
 ```yaml
 ---
 title: Project name
 description: One-line summary.
 tech: ['Astro', 'TypeScript']
-link: https://example.com # optional — live link
-repo: https://github.com/... # optional — source
-thumbnail: ./cover.png # optional — relative image
-order: 1 # optional — manual sort
+link: https://example.com        # optional — live link
+repo: https://github.com/...     # optional — source
+thumbnail: ./cover.png           # optional — relative image
+order: 1                         # optional — manual sort
 publishDate: 2026-06-01
 ---
 ```
 
 ### Blog frontmatter
 
+<!-- prettier-ignore -->
 ```yaml
 ---
 title: Post title
 publishDate: 2026-06-01
 description: One-line summary for listings, SEO, and RSS.
 tags: ['design', 'astro']
-draft: false # true hides it from build output
-heroImage: ./hero.png # optional — relative image
+draft: false                     # true hides it from build output
+heroImage: ./hero.png            # optional — relative image
 ---
 ```
 


### PR DESCRIPTION
## 概要
- `.vscode/extensions.json` を新規追加し、`esbenp.prettier-vscode` と `astro-build.astro-vscode` を推奨拡張として設定
- `.editorconfig` に `.prettierrc` の `printWidth` と揃う `max_line_length = 100` を追加
- README のfrontmatter例（Works/Blog）で、Prettierが崩していたコメントの縦位置揃えを `<!-- prettier-ignore -->` で復元
- `.prettierrc` の `*.astro` 用 parser override を検証の上削除（`prettier-plugin-astro` が拡張子で自動的にparserを登録するため冗長と確認）

## 確認事項
- [x] `npm run format:check` が通ることを確認（override削除前後の両方で確認）
- [x] VS Codeでリポジトリを開いた際に2つの推奨拡張がプロンプトされることをレビュー時に確認してください

Closes #41