### PR TITLE
ci: auto-create GitHub Releases from CHANGELOG on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 # Scoped to this workflow only — ci.yml and deploy.yml stay read-only.
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Scoped to this workflow only — ci.yml and deploy.yml stay read-only.
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Extract CHANGELOG section
+        # Keep a Changelog headings look like "## [0.2.0] - 2026-08-03". Pull
+        # everything between the heading matching this tag's version and the
+        # next "## [" heading (or EOF), and fail loudly if that section is
+        # missing or empty — the guard against tagging before writing notes.
+        run: |
+          set -uo pipefail
+          version="${GITHUB_REF_NAME#v}"
+
+          if ! awk -v ver="$version" '
+            BEGIN { gsub(/\./, "\\.", ver); found = 0; printing = 0 }
+            /^## \[/ {
+              if (printing) exit
+              if ($0 ~ "^## \\[" ver "\\]") { found = 1; printing = 1 }
+              next
+            }
+            # Stop before the link reference definitions at the bottom of the
+            # file — otherwise the oldest section in CHANGELOG.md would run
+            # past its own content into "[0.1.0]: https://...".
+            printing && /^\[[^]]+\]:/ { exit }
+            printing { print }
+            END { exit !found }
+          ' CHANGELOG.md > release-notes.md; then
+            echo "::error::No CHANGELOG.md section found for version $version (tag $GITHUB_REF_NAME)"
+            exit 1
+          fi
+
+          if [ ! -s release-notes.md ]; then
+            echo "::error::CHANGELOG.md section for version $version is empty (tag $GITHUB_REF_NAME)"
+            exit 1
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          name: ${{ github.ref_name }}
+          body_path: release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ written with that in mind — each one names the files it touches.
   expression-wrapped `<style>`.
 - **`.editorconfig`** covering charset, line endings, and indentation for
   editors that do not run Prettier.
+- **`.github/workflows/release.yml`** — pushing a `vX.Y.Z` tag now extracts
+  that version's section from `CHANGELOG.md` and publishes it as the GitHub
+  Release body automatically, replacing the manual `gh release create` step.
+  The workflow fails loudly if the tag has no matching CHANGELOG section.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,12 +114,10 @@ Maintainers only.
    git push origin main --tags
    ```
 
-4. Publish the GitHub Release, using that changelog section as the body — paste
-   it in and close with `Ctrl-D`:
-
-   ```sh
-   gh release create vx.y.z --title "vx.y.z" --notes-file -
-   ```
+   Pushing the tag triggers `.github/workflows/release.yml`, which extracts
+   that version's section from `CHANGELOG.md` and publishes the GitHub
+   Release with it as the body. The workflow fails if the tag has no matching
+   CHANGELOG section — that's the guard against tagging before writing notes.
 
 The Lighthouse table in the README is a hand-recorded snapshot, not a live
 badge — re-run it before cutting a release so a regression can't sit behind a


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml`, triggered on `push` of tags matching `v*`
- Extract the matching version's section from `CHANGELOG.md` via a small awk script and publish it as the GitHub Release body with `softprops/action-gh-release`
- Fail loudly (`::error::`) if the tag has no matching CHANGELOG section, or if the section is empty
- `permissions: contents: write` scoped to this workflow only
- Update `CONTRIBUTING.md` release procedure: the manual `gh release create` step is gone; pushing the tag now publishes the release
- Add a CHANGELOG entry under `## [Unreleased]`

## Test plan
- [x] Verified the awk extraction logic locally against the current `CHANGELOG.md` for `0.2.0`, `0.1.0` (including the edge case where the oldest section would otherwise swallow the trailing link-reference definitions), and `Unreleased`
- [x] Verified extraction fails for a nonexistent version (`9.9.9`)
- [x] Validated workflow YAML syntax
- [x] End-to-end: push a real `vX.Y.Z` tag and confirm the Release is created with the correct body

Closes #31