### PR TITLE
ci: check for dead links weekly with lychee

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,75 @@
+name: Links
+
+on:
+  # Weekly — external links rot on their own schedule, not on ours.
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+# Deliberately not on `pull_request`: a link check depends on other people's
+# servers being up, and a flaky host must never block a merge. Failures land in
+# a tracking issue instead.
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: links
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Report rather than fail, so the issue steps below always run.
+          fail: false
+          jobSummary: true
+          # Links inside code fences are skipped by default (no
+          # `--include-verbatim`) — the docs are full of illustrative URLs.
+          args: >-
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            --exclude-path node_modules
+            --exclude-path dist
+            '**/*.md'
+            '**/*.mdx'
+
+      - name: Look for an open report issue
+        id: report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # One tracking issue at a time: a weekly run that finds the same dead
+        # link should edit last week's report, not stack another issue on it.
+        run: |
+          set -euo pipefail
+          number=$(gh issue list --state open --label link-check --limit 1 --json number --jq '.[0].number // empty')
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the report issue
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v6
+        with:
+          title: Dead links found
+          content-filepath: ./lychee/out.md
+          # Empty when nothing is open, which makes this a fresh issue.
+          issue-number: ${{ steps.report.outputs.number }}
+          labels: link-check
+
+      - name: Close the report issue once links are healthy
+        if: steps.lychee.outputs.exit_code == 0 && steps.report.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ steps.report.outputs.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh issue close "$NUMBER" --comment "Every link resolves again as of $RUN_URL."

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
+# lychee's link-check cache, written when the workflow's command is run locally
+.lycheecache
+
 # editor / agent local state
 .codex/
 .claude/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,19 @@
+# Patterns (regex) for links the weekly check in .github/workflows/links.yml
+# must not try to resolve.
+
+# The dev server, which only exists on a contributor's machine.
+^http://localhost
+
+# Placeholders in setup instructions and demo content. They stand in for the
+# reader's own values and are never meant to resolve.
+^https://example\.com
+^https://your-domain\.com
+^https://<user
+^https://github\.com/<user
+^https://github\.com/\.\.\.
+^https://github\.com/example/
+
+# GitHub serves the stargazers page to browsers only — an unauthenticated bot
+# request 404s even for repositories that have stars. The README badge links
+# there and the link is fine.
+^https://github\.com/[^/]+/[^/]+/stargazers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ written with that in mind — each one names the files it touches.
   that version's section from `CHANGELOG.md` and publishes it as the GitHub
   Release body automatically, replacing the manual `gh release create` step.
   The workflow fails loudly if the tag has no matching CHANGELOG section.
+- **`.github/workflows/links.yml`** — a weekly `lychee` run over every
+  Markdown and MDX file, reporting dead external links in a single tracking
+  issue that later runs update and close. It never runs on pull requests, so
+  an external site being down can't block a merge. Placeholder and
+  dev-server URLs are listed in `.lycheeignore`.
 
 ### Changed
 


### PR DESCRIPTION
## What

Adds `.github/workflows/links.yml`: a weekly `lychee` run over every Markdown
and MDX file, reporting broken external links into a single tracking issue.
`.lycheeignore` carries the exclusions.

## Why

External links rot silently, and dead links in a theme's README cost
credibility with people evaluating the template. Nothing in the repo noticed
until a visitor hit a 404.

Closes #30

Details worth reviewing:

- **Not on `pull_request`.** A link check depends on other people's servers
  being up; a flaky host must never block a merge. Schedule + `workflow_dispatch`
  only.
- **One issue, not a pile.** The run looks for an open `link-check` issue and
  passes its number to `create-issue-from-file`, which updates it instead of
  opening a duplicate. When every link resolves again, the issue is closed with
  a link to the run.
- **Exclusions.** Placeholder URLs (`example.com`, `your-domain.com`,
  `<user>`), the dev server, and GitHub's `/stargazers` path — the last one
  404s for unauthenticated bots even on `withastro/astro`, so the README badge
  link is fine and the checker is wrong.
- Links inside code fences are skipped (no `--include-verbatim`), which keeps
  the illustrative URLs in the docs out of scope.

The `link-check` label already exists in the repo.

## Verification

`lychee 0.24.2` run locally with the workflow's exact arguments: 45 unique
links, 0 errors. The first run flagged only the `/stargazers` false positive,
which the ignore file now covers.

`workflow_dispatch` can't be exercised from a branch — GitHub only dispatches
workflows present on the default branch — so the manual run in the acceptance
criteria happens right after merge.

## Checklist

- [x] `npm run check` passes (0 errors)
- [x] `npm run build` succeeds
- [ ] Verified in both light and dark mode (visual changes only)
- [ ] New config options are documented in `src/consts.ts` comments and the README
- [ ] New features that add client-side weight are opt-in (off by default)
