### PR TITLE
docs: record that src/content/ stays under the Prettier gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,23 @@ hand-wrapped, and `src/components/Comments.astro`, which the Astro plugin cannot
 parse — its `<style>` is wrapped in a JSX expression, the only way to scope CSS
 inside `{enabled && …}`. Keep that file tidy by hand.
 
+`src/content/` is formatted too. Prose is left alone — `proseWrap` stays at the
+default `preserve`, so paragraphs are never rewrapped — but frontmatter quoting
+is normalised and fenced code blocks are reformatted. When a code block has to
+stay verbatim, for instance because the post is about the broken formatting,
+mark it:
+
+````md
+<!-- prettier-ignore -->
+```js
+const   x=1
+```
+````
+
+Downstream users who would rather keep their own posts out of the gate can add
+`src/content/` to `.prettierignore` — the demo content in this repo stays under
+it because it ships as part of the theme.
+
 ## Project structure
 
 ```


### PR DESCRIPTION
## What

Records the decision that `src/content/` stays under the Prettier gate, in the
Formatting section of CONTRIBUTING.md, and documents the escape hatch.

## Why

#38 put the whole tree under `prettier --check`, `src/content/` included. That
is right for this repo — the demo content ships as part of the theme — but the
consequences weren't written down anywhere, and #40 asked for the decision to
live in the repo rather than in a PR thread.

Closes #40

The added paragraph covers the three things a contributor actually needs:

- Prose is safe. `proseWrap` stays at `preserve`, so paragraphs are never
  rewrapped.
- Frontmatter quoting is normalised and fenced code blocks *are* reformatted —
  the part that surprises people.
- `<!-- prettier-ignore -->` before a fence keeps a code block verbatim, which
  matters for a post that is about the broken formatting. Shown as a worked
  example rather than described.

It closes by pointing downstream users at `.prettierignore` if they'd rather
keep their own posts out of the gate.

## Checklist

- [x] `npm run check` passes (0 errors)
- [x] `npm run build` succeeds
- [ ] Verified in both light and dark mode (visual changes only)
- [ ] New config options are documented in `src/consts.ts` comments and the README
- [ ] New features that add client-side weight are opt-in (off by default)
